### PR TITLE
Further ReadTheDocs build environment changes.

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -8,7 +8,6 @@ dependencies:
     - python>=3.5
     - numpy
     - astropy
-    - fftw
     - pyfftw
     - pip:
       - sphinx_astropy

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -2,9 +2,14 @@ name: scintillometry
 
 channels:
     - astropy
+    - conda-forge
 
 dependencies:
-    - astropy
+    - python>=3.5
     - numpy
+    - astropy
+    - fftw
+    - pyfftw
     - pip:
+      - sphinx_astropy
       - baseband


### PR DESCRIPTION
The last change didn't result in a successful build, but I made some further changes that should now make it work.

I don't know why we need to install `sphinx_astropy` - perhaps the Python 3 requirement forces it?  In any case, RTD complains if it's not included under `pip`.