### PR TITLE
Fix badges reporting 'unknown'.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,12 @@ Project Status
 --------------
 
 .. image:: https://travis-ci.org/mhvk/scintillometry.svg?branch=master
+   :target: https://travis-ci.org/mhvk/scintillometry
 
-.. image:: https://coveralls.io/repos/github/mhvk/scintillometry/badge.svg
-   :target: https://coveralls.io/github/mhvk/scintillometry
+.. image:: https://coveralls.io/repos/github/mhvk/scintillometry/badge.svg?branch=master
+   :target: https://coveralls.io/github/mhvk/scintillometry?branch=master
 
-.. image:: //readthedocs.org/projects/scintillometry/badge/?version=latest
+.. image:: https://readthedocs.org/projects/scintillometry/badge/?version=latest
    :target: https://scintillometry.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,16 @@ given correct inputs.
 Project details
 ===============
 
+.. image:: https://travis-ci.org/mhvk/scintillometry.svg?branch=master
+   :target: https://travis-ci.org/mhvk/scintillometry
+
+.. image:: https://coveralls.io/repos/github/mhvk/scintillometry/badge.svg?branch=master
+   :target: https://coveralls.io/github/mhvk/scintillometry?branch=master
+
+.. image:: https://readthedocs.org/projects/scintillometry/badge/?version=latest
+   :target: https://scintillometry.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
(Hopefully) fix badges reporting 'unknown' in Readme.rst, and added badges to the docs.

Oddly, despite there being a cron job, Scintillometry has never built the master branch, which is why Travis reports its build status as unknonwn and Coveralls can't track anything.  I manually triggered a master build on Travis, which alleviated the problem.  @mhvk, could you fiddle with the cron job to see if it can build regularly?