### PR TITLE
WIP Coherent dedispersion module

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ classes that can be linked together into a data reduction pipeline.
 .. toctree::
    :maxdepth: 1
 
+   tasks/dedisperse
    tasks/channelize
    tasks/square
    tasks/base

--- a/docs/tasks/dedisperse.rst
+++ b/docs/tasks/dedisperse.rst
@@ -1,0 +1,16 @@
+.. _dedisperse:
+
+****************************************
+Dedisperse (`scintillometry.dedisperse`)
+****************************************
+
+`~scintillometry.dedisperse` uses the :ref`dispersion measure <dm>` to correct
+for the frequency-dependent slowing of radio signals passing through plasma.
+
+.. _dedisperse_api:
+
+Reference/API
+=============
+
+.. automodapi:: scintillometry.dedisperse
+   :no-inherited-members:

--- a/scintillometry/dedisperse.py
+++ b/scintillometry/dedisperse.py
@@ -1,0 +1,121 @@
+# Licensed under the GPLv3 - see LICENSE
+
+import numpy as np
+import astropy.units as u
+import operator
+from astropy.utils import lazyproperty
+
+from .base import TaskBase
+from .fourier import get_fft_maker
+from .dm import DispersionMeasure
+
+
+__all__ = ['CoherentDedispersionTask']
+
+
+class CoherentDedispersionTask(TaskBase):
+
+    def __init__(self, ih, dm, base_freq, pad_samples_per_frame,
+                 freq_order=None, FFT=None):
+
+        # Store the number of inputs samples to read per frame.
+        self._pad_samples_per_frame = operator.index(pad_samples_per_frame)
+
+        # Set reference frequency.  If not complex, base_freq is at the edge of
+        # the band, and freq_order determines which edge (1 for bottom, -1 for
+        # top).  If complex, base_freq is at the middle of the band.
+        # NOTE: unless the exact bandwidth edge is returned by np.fft.rfftfreq,
+        # this will give slightly different answers than Rob's code.
+        self._base_freq = np.atleast_1d(np.array(base_freq)) * base_freq.unit
+        # Set the frequency order (1 for increasing, -1 for decreasing).
+        if freq_order is None:
+            freq_order = np.ones(ih.sample_shape, dtype=int)
+        self._freq_order = np.atleast_1d(np.array(freq_order))
+
+        half_rate = ih.sample_rate.value / 2.
+        if not ih.complex_data:
+            bandwidth = np.array([0., half_rate]) * ih.sample_rate.unit
+        else:
+            bandwidth = np.array([-half_rate, half_rate]) * ih.sample_rate.unit
+        extrema_freqs = self.base_freq + (self.freq_order *
+                                          bandwidth[:, np.newaxis])
+        self._max_freq = np.max(extrema_freqs)
+
+        # Set dispersion measure.
+        self.dm = DispersionMeasure(dm)
+
+        # Calculate maximum time delay, and determine the size of padding
+        # needed to account for dispersion.
+        max_time_delay = self.dm.time_delay(np.min(extrema_freqs),
+                                            self.max_freq)
+        max_delay_offset = int(np.ceil((max_time_delay *
+                                        ih.sample_rate).to_value(u.one)))
+        samples_per_frame = self._pad_samples_per_frame - max_delay_offset
+        assert samples_per_frame > 0, (
+            "pad_samples_per_frame={} is smaller than the minimum number "
+            "needed for dedispersion, {}".format(pad_samples_per_frame,
+                                                 max_delay_offset + 1))
+
+        # Calculate task output shape and sample rate.
+        nframe, remaining_samples = divmod(ih.shape[0], samples_per_frame)
+        # HACK: We don't support partial frames yet, so if nframe > 1 but
+        # remaining_samples < max_delay_offset, we reduce the number of frames
+        # by an appropriate amount to prevent EOF errors.
+        if nframe > 1 and remaining_samples < max_delay_offset:
+            if samples_per_frame > max_delay_offset:
+                nframe -= 1
+                remaining_samples += samples_per_frame
+            else:
+                subtract_nframes = max_delay_offset // samples_per_frame + 1
+                nframe -= subtract_nframes
+                remaining_samples += samples_per_frame * subtract_nframes
+        assert nframe > 0, "not enough samples to fill one frame of data!"
+        self._nsample = samples_per_frame * nframe
+
+        # Initialize FFT.
+        if FFT is None:
+            FFT = get_fft_maker('numpy')
+        # Dedispersion FFT and inverse.
+        self._fft = FFT((self._pad_samples_per_frame,) + ih.sample_shape,
+                        self.ih.dtype, axis=0, sample_rate=self.ih.sample_rate)
+        self._ifft = self._fft.inverse()
+
+        super().__init__(ih, (self._nsample,) + ih.sample_shape,
+                         ih.sample_rate, samples_per_frame, ih.dtype)
+
+    @property
+    def base_freq(self):
+        return self._base_freq
+
+    @property
+    def max_freq(self):
+        return self._max_freq
+
+    @property
+    def freq_order(self):
+        return self._freq_order
+
+    @lazyproperty
+    def freq(self):
+        return self.base_freq + self.freq_order * self._fft.freq
+
+    @lazyproperty
+    def phase_factor(self):
+        phase_factor = self.dm.phase_factor(self.freq, self.max_freq)
+        phase_factor[:, self.freq_order == 1] = (
+            np.conj(phase_factor[:, self.freq_order == 1]))
+        return phase_factor
+
+    def dedisperse(self, data):
+        return self._ifft(self._fft(data) *
+                          self.phase_factor)[:self._samples_per_frame]
+
+    def _read_frame(self, frame_index):
+        # TODO: For speed during sequential reading, can buffer frames, then,
+        # during sequential decode, copy data from self._samples_per_frame to
+        # self._pad_samples_per_frame into the next buffer, rather than
+        # re-decoding them.  Dangerous if self.ih gets manually shifted
+        # between reads.
+        self.ih.seek(frame_index * self._samples_per_frame)
+        data = self.ih.read(self._pad_samples_per_frame)
+        return self.dedisperse(data)


### PR DESCRIPTION
Revised dedispersion module (featuring only coherent dedispersion), based directly off of @ramain's [ReadDD class](https://github.com/ramain/scint_reduction/blob/master/scint_reduction/ReadDD.py).  Docstrings and sparse documentation exist, but no tests yet.

I have successfully tested this against a manual dedispersion script I wrote that can reproduce `ReadDD` to floating-point precision.  I include this below in the hopes it may help inspire a test suite (or at least help troubleshoot any strange behaviour by the module):

```
import numpy as np
import astropy.units as u
from baseband import mark4
from scintillometry.fourier import get_fft_maker
from scintillometry.dedisperse import CoherentDedispersionTask
from scintillometry.dm import DispersionMeasure

##### Manual dedispersion #####

# Original file from bgq:/scratch/r/rein/arachkov/DataFromJohnsDir/Ar/
filename = './mountbgq/gp052a_ar_no0016'
fh = mark4.open(filename, decade=2010, subset=slice(0, 4))
sample_rate = fh.sample_rate
subset = (0, 1, 2, 3)
f_edge = np.array([311.25, 311.25, 327.25, 327.25]) * u.MHz
f_order = np.ones(4, dtype='int')

dm = 29.118838176 * u.pc / u.cm**3
dm = DispersionMeasure(dm)

size = 2**24

FFT = get_fft_maker('pyfftw', threads=8, planning_timelimit=1.)
fft = FFT((size,) + fh.sample_shape,
          fh.dtype, direction='forward', axis=0, ortho=False,
          sample_rate=fh.sample_rate)
ifft = fft.inverse()
freqs = f_edge + f_order * fft.freq

max_freq = np.max(freqs)
dmloss = dm.time_delay(np.min(freqs), max_freq)
samploss = int(np.ceil((dmloss * sample_rate).to(u.one)))
step = int(size - samploss)

dd = dm.phase_factor(freqs, max_freq)
dd[:, f_order == 1] = np.conj(dd[:, f_order == 1])

d = fh.read(size)
ft = fft(d)
ft *= dd
d = ifft(ft)
ref_data = d[:step]

##### Using Scintillometry #####

ih = mark4.open(filename, decade=2010, subset=slice(0, 4))
ddt = CoherentDedispersionTask(ih, dm, size, f_edge, FFT=get_fft_maker(
    'pyfftw', planning_timelimit=1, threads=8))
data = ddt._read_frame(0)

##### Checks #####

assert ddt.dm == dm
assert ddt.max_freq == max_freq
assert ddt._pad_samples_per_frame == size
assert ddt._samples_per_frame == size - samploss
nsamples = (fh.shape[0] // ddt._samples_per_frame - 1) * (size - samploss)
assert ddt.shape == (nsamples,) + fh.sample_shape
assert ddt._fft == fft
assert np.all(ddt.freq == freqs)
assert np.all(ddt.phase_factor == dd)
assert np.all(ref_data == data)
ddt.seek(373)
assert np.all(ref_data[373:385] == ddt.read(12))
```