### PR TITLE
Refactor

### DIFF
--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -421,6 +421,8 @@ class Task(TaskBase):
                 narg = len(argspec.args)
                 if argspec.defaults:
                     narg -= len(argspec.defaults)
+                if inspect.ismethod(task):
+                    narg -= 1
                 assert 1 <= narg <= 2
                 method = narg == 2
             except Exception as exc:

--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -1,6 +1,9 @@
 # Licensed under the GPLv3 - see LICENSE
 
+import inspect
 import operator
+import types
+
 import numpy as np
 import astropy.units as u
 
@@ -279,9 +282,9 @@ class TaskBase(Base):
 
     This class provides a base ``_read_frame`` method that will read
     a frame worth of data from the underlying stream and pass it on to
-    a function method.  Hence, subclasses should define:
+    a task method.  Hence, subclasses should define:
 
-      ``function(self, data)`` : return processed data from one frame.
+      ``task(self, data)`` : return processed data from one frame.
 
     Parameters
     ----------
@@ -358,9 +361,77 @@ class TaskBase(Base):
         data = self.ih.read(self._raw_samples_per_frame)
         # Apply function to the data.  Note that the read() function
         # in base ensures that our offset pointer is correct.
-        return self.function(data)
+        return self.task(data)
 
     def close(self):
         """Close task, in particular closing its input source."""
         super().close()
         self.ih.close()
+
+
+class Task(TaskBase):
+    """Apply a user-supplied callable to a stream.
+
+    The task can either behave like a function or a method.  If a function,
+    it will be passed just the frame data read from the underlying file or task;
+    if a method, it will be passed the Task instance (with its offset at the
+    correct sample) as well as the frame data read.
+
+    Note that for common functions it is recommended to instead define a
+    new subclass of `~scintillometry.base.TaskBase` in which a ``task``
+    (static)method is defined.
+
+    Parameters
+    ----------
+    ih : filehandle
+        Source of data, or another task, from which samples are read.
+    task : callable
+        The function or method-like callable.
+    method : bool, optional
+        Whether ``task`` is a method (two arguments) or a function
+        (one argument).  Default: inferred by inspection.
+    shape : tuple, optional
+        Overall shape of the stream, with first entry the total number
+        of complete samples, and the remainder the sample shape.  By
+        default, the shape of the underlying stream, possibly adjusted
+        for a difference of sample rate.
+    sample_rate : `~astropy.units.Quantity`, optional
+        With units of a rate.  If not given, taken from the underlying
+        stream.  Should be passed in if the function reduces or expands
+        the number of elements.
+    samples_per_frame : int, optional
+        Number of samples which should be fed to the function in one go.
+        If not given, by default the number from the underlying file,
+        possibly adjusted for a difference in sample rate.
+    dtype : `~numpy.dtype`, optional
+        Output dtype.  If not given, the dtype of the underlying file.
+
+    Raises
+    ------
+    TypeError
+        If inspection of the task does not work.
+    AssertionError
+        If the task has zero or more than 2 arguments.
+    """
+    def __init__(self, ih, task, method=None, shape=None, sample_rate=None,
+                 samples_per_frame=None, dtype=None):
+        if method is None:
+            try:
+                argspec = inspect.getfullargspec(task)
+                narg = len(argspec.args)
+                if argspec.defaults:
+                    narg -= len(argspec.defaults)
+                assert 1 <= narg <= 2
+                method = narg == 2
+            except Exception as exc:
+                exc.args += ("cannot determine whether ``task`` is a "
+                             "function or method. Pass in ``method``.",)
+                raise
+
+        if method:
+            self.task = types.MethodType(task, self)
+        else:
+            self.task = task
+
+        super().__init__(ih, shape=shape, sample_rate=sample_rate,
+                         samples_per_frame=samples_per_frame, dtype=dtype)

--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -299,12 +299,19 @@ class TaskBase(Base):
         ``shape`` will be adjusted to make the total number of samples
         an integer multiple of ``samples_per_frame``.  If not given,
         the number from the underlying stream.
+    frequency : `~astropy.units.Quantity`, optional
+        Frequencies for each channel.  Should be broadcastable to the
+        sample shape.  Default: taken from the underlying stream, if available.
+    sideband : array, optional
+        Whether frequencies are upper (+1) or lower (-1) sideband.
+        Should be broadcastable to the sample shape.
+        Default: taken from the underlying stream, if available.
     dtype : `~numpy.dtype`, optional
-        Output dtype.  If not given, the dtype of the underlying file.
+        Output dtype.  If not given, the dtype of the underlying stream.
     """
 
     def __init__(self, ih, shape=None, sample_rate=None,
-                 frequency=None, sideband=None, samples_per_frame=None,
+                 samples_per_frame=None, frequency=None, sideband=None,
                  dtype=None):
         self.ih = ih
         if sample_rate is None:

--- a/scintillometry/functions.py
+++ b/scintillometry/functions.py
@@ -4,85 +4,10 @@ import numpy as np
 from .base import TaskBase
 
 
-__all__ = ['FunctionTask', 'ComplexFunctionTask', 'SquareTask']
+__all__ = ['Square']
 
 
-class FunctionTask(TaskBase):
-    """Apply a user-supplied function to a stream.
-
-    The function will be fed data from the underlying stream.  If
-    knowledge of the state of the stream is needed, use
-    `ComplexFunctionTask`.
-
-    Parameters
-    ----------
-    ih : filehandle
-        Source of data, or another task, from which samples are read.
-    function : callable
-        The function should take a single argument, which will be the
-        frame data read from the underlying file or task.
-    shape : tuple, optional
-        Overall shape of the stream, with first entry the total number
-        of complete samples, and the remainder the sample shape.  By
-        default, the shape of the underlying stream, possibly adjusted
-        for a difference of sample rate.
-    sample_rate : `~astropy.units.Quantity`, optional
-        With units of a rate.  If not given, taken from the underlying
-        stream.  Should be passed in if the function reduces or expands
-        the number of elements.
-    samples_per_frame : int, optional
-        Number of samples which should be fed to the function in one go.
-        If not given, by default the number from the underlying file,
-        possibly adjusted for a difference in sample rate.
-    dtype : `~numpy.dtype`, optional
-        Output dtype.  If not given, the dtype of the underlying file.
-    """
-    def __init__(self, ih, function, shape=None, sample_rate=None,
-                 samples_per_frame=None, dtype=None):
-        self._function = function
-        super().__init__(ih, shape=shape, sample_rate=sample_rate,
-                         samples_per_frame=samples_per_frame, dtype=dtype)
-
-    def function(self, data):
-        return self._function(data)
-
-
-class ComplexFunctionTask(FunctionTask):
-    """Apply a user-supplied function to a stream.
-
-    Like `~scintillometry.functions.FunctionTask`, but for a callable
-    that requires knowledge of the state of the stream.
-
-    Parameters
-    ----------
-    ih : filehandle
-        Source of data, or another task, from which samples are read.
-    function : callable
-        The function should take two arguments, which will be the
-        Function task instance, with its offset at the sample for which
-        the amplitude should be returned, and the frame data read from
-        the underlying file or task.
-    shape : tuple, optional
-        Overall shape of the stream, with first entry the total number
-        of complete samples, and the remainder the sample shape.  By
-        default, the shape of the underlying stream, possibly adjusted
-        for a difference of sample rate.
-    sample_rate : `~astropy.units.Quantity`, optional
-        With units of a rate.  If not given, taken from the underlying
-        stream.  Should be passed in if the function reduces or expands
-        the number of elements.
-    samples_per_frame : int, optional
-        Number of samples which should be fed to the function in one go.
-        If not given, by default the number from the underlying file,
-        possibly adjusted for a difference in sample rate.
-    dtype : `~numpy.dtype`, optional
-        Output dtype.  If not given, the dtype of the underlying file.
-    """
-    def function(self, data):
-        return self._function(self, data)
-
-
-class SquareTask(FunctionTask):
+class Square(TaskBase):
     """Converts samples to intensities by squaring.
 
     Parameters
@@ -99,6 +24,6 @@ class SquareTask(FunctionTask):
             def square(x):
                 return np.square(x.real) + np.square(x.imag)
 
-        dtype = square(np.zeros(1, dtype=ih_dtype)).dtype
-
-        super().__init__(ih, function=square, dtype=dtype)
+        self.task = square
+        dtype = self.task(np.zeros(1, dtype=ih_dtype)).dtype
+        super().__init__(ih, dtype=dtype)

--- a/scintillometry/generators.py
+++ b/scintillometry/generators.py
@@ -111,7 +111,7 @@ class EmptyStreamGenerator(Base):
     Produce alternating +/-1 in single-channel data with decent-sized blocks.
 
     >>> from scintillometry.generators import EmptyStreamGenerator
-    >>> from scintillometry.functions import FunctionTask
+    >>> from scintillometry.base import Task
     >>> import numpy as np
     >>> from astropy import time as t, units as u
     >>> def alternate(data):
@@ -122,7 +122,7 @@ class EmptyStreamGenerator(Base):
     >>> eh = EmptyStreamGenerator((1000,), t.Time('2010-11-12'),
     ...                           1.*u.kHz, samples_per_frame=100,
     ...                           dtype='f4')
-    >>> sh = FunctionTask(eh, alternate)
+    >>> sh = Task(eh, alternate)
     >>> sh.seek(995)
     995
     >>> sh.read()  # doctest: +FLOAT_CMP

--- a/scintillometry/tests/test_base.py
+++ b/scintillometry/tests/test_base.py
@@ -6,7 +6,7 @@ import operator
 import pytest
 import itertools
 
-from ..base import TaskBase
+from ..base import TaskBase, Task
 
 from baseband import vdif
 from baseband.data import SAMPLE_VDIF
@@ -29,7 +29,7 @@ class ReshapeTask(TaskBase):
                          sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame, **kwargs)
 
-    def function(self, data):
+    def task(self, data):
         return data.reshape((-1,) + self.sample_shape)
 
 
@@ -161,3 +161,77 @@ class TestTaskBase:
             with pytest.raises(ValueError):
                 ReshapeTask(fh, 1024, samples_per_frame=3,
                             sideband=np.ones((2, 8), dtype=int))
+
+def zero_channel_4(data):
+    data[:, 4] = 0.
+    return data
+
+
+def zero_every_8th_sample(data):
+    data[::8] = 0.
+    return data
+
+
+def remove_every_other(data):
+    return data[::2]
+
+
+def double_data(data):
+    return np.stack((data, data), axis=1).reshape((-1,) + data.shape[1:])
+
+
+def zero_every_8th_complex(fh, data):
+    every_8th = (fh.tell() + np.arange(fh.samples_per_frame)) % 8 == 0
+    data[every_8th] = 0.
+    return data
+
+
+class TestTasks:
+    """Test applying tasks to Baseband's sample VDIF file."""
+
+    @pytest.mark.parametrize('task, sample_factor',
+                             ((zero_channel_4, 1.),
+                              (zero_every_8th_sample, 1.),
+                              (remove_every_other, 0.5),
+                              (double_data, 2.)))
+    def test_function_tasks(self, task, sample_factor):
+        """Test setting a channel to zero."""
+
+        # Load baseband file and get reference intensities.
+        fh = vdif.open(SAMPLE_VDIF)
+        ref_data = task(fh.read())
+
+        ft = Task(fh, task, sample_rate=fh.sample_rate * sample_factor)
+
+        assert ft.shape[0] == fh.shape[0] * sample_factor
+        # Apply to everything.
+        data1 = ft.read()
+        assert ft.tell() == ft.shape[0]
+        assert (ft.time - ft.start_time -
+                ft.shape[0] / ft.sample_rate) < 1*u.ns
+        assert ft.dtype is ref_data.dtype is data1.dtype
+        assert np.allclose(ref_data, data1)
+
+        # Seeking and selective zeroing.
+        ft.seek(-3, 2)
+        assert ft.tell() == ft.shape[0] - 3
+        data2 = ft.read()
+        assert data2.shape[0] == 3
+        assert np.allclose(ref_data[-3:], data2)
+
+        ft.close()
+
+    @pytest.mark.parametrize('samples_per_frame', (None, 15, 1000))
+    def test_method_task(self, samples_per_frame):
+        fh = vdif.open(SAMPLE_VDIF)
+        count = fh.shape[0]
+        if samples_per_frame is not None:
+            count = (count // samples_per_frame) * samples_per_frame
+        ref_data = zero_every_8th_sample(fh.read(count))
+
+        ft = Task(fh, zero_every_8th_complex,
+                  samples_per_frame=samples_per_frame)
+
+        data1 = ft.read()
+
+        assert np.all(data1 == ref_data)

--- a/scintillometry/tests/test_base.py
+++ b/scintillometry/tests/test_base.py
@@ -12,10 +12,10 @@ from baseband import vdif
 from baseband.data import SAMPLE_VDIF
 
 
-class ReshapeTask(TaskBase):
+class Reshape(TaskBase):
     """Dummy class to test accessing task properties and methods.
 
-    `ReshapeTask` simply reshapes blocks of baseband data into frames.
+    `Reshape` simply reshapes blocks of baseband data into frames.
     """
 
     def __init__(self, ih, n, samples_per_frame=1, **kwargs):
@@ -46,7 +46,7 @@ class TestTaskBase:
         self-consistency with varying ``n`` and ``samples_per_frame``.
         """
         fh = vdif.open(SAMPLE_VDIF)
-        rt = ReshapeTask(fh, n, samples_per_frame=samples_per_frame)
+        rt = Reshape(fh, n, samples_per_frame=samples_per_frame)
 
         # Check sample pointer.
         assert rt.sample_rate == fh.sample_rate / n
@@ -105,7 +105,7 @@ class TestTaskBase:
         # (Note: sideband is incorrect; just for testing purposes)
         fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 2) * 16. * u.MHz
         fh.sideband = np.tile([-1, +1], 4)
-        rt = ReshapeTask(fh, 256)
+        rt = Reshape(fh, 256)
         assert np.all(rt.sideband == fh.sideband)
         assert np.all(rt.frequency == fh.frequency)
 
@@ -115,7 +115,7 @@ class TestTaskBase:
         # (Note: sideband is incorrect; just for testing purposes)
         frequency_in = 311.25 * u.MHz + (np.arange(8.) // 2) * 16. * u.MHz
         sideband_in = np.tile([-1, +1], 4)
-        rt = ReshapeTask(fh, 256, frequency=frequency_in, sideband=sideband_in)
+        rt = Reshape(fh, 256, frequency=frequency_in, sideband=sideband_in)
         assert np.all(rt.sideband == sideband_in)
         assert np.all(rt.frequency == frequency_in)
 
@@ -123,7 +123,7 @@ class TestTaskBase:
         """Test exceptions in TaskBase."""
 
         with vdif.open(SAMPLE_VDIF) as fh:
-            rt = ReshapeTask(fh, 1024, samples_per_frame=3)
+            rt = Reshape(fh, 1024, samples_per_frame=3)
 
             # Check that reading beyond the bounds of the data leads to an
             # error.
@@ -156,11 +156,12 @@ class TestTaskBase:
             with pytest.raises(AttributeError):
                 rt.sideband
             with pytest.raises(ValueError):
-                ReshapeTask(fh, 1024, samples_per_frame=3,
-                            frequency=np.arange(4.)*u.GHz)
+                Reshape(fh, 1024, samples_per_frame=3,
+                        frequency=np.arange(4.)*u.GHz)
             with pytest.raises(ValueError):
-                ReshapeTask(fh, 1024, samples_per_frame=3,
-                            sideband=np.ones((2, 8), dtype=int))
+                Reshape(fh, 1024, samples_per_frame=3,
+                        sideband=np.ones((2, 8), dtype=int))
+
 
 def zero_channel_4(data):
     data[:, 4] = 0.

--- a/scintillometry/tests/test_functions.py
+++ b/scintillometry/tests/test_functions.py
@@ -4,86 +4,10 @@ import pytest
 import numpy as np
 import astropy.units as u
 
-from ..functions import FunctionTask, ComplexFunctionTask, SquareTask
+from ..functions import Square
 
 from baseband import vdif, dada
 from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
-
-
-def zero_channel_4(data):
-    data[:, 4] = 0.
-    return data
-
-
-def zero_every_8th_sample(data):
-    data[::8] = 0.
-    return data
-
-
-def remove_every_other(data):
-    return data[::2]
-
-
-def double_data(data):
-    return np.stack((data, data), axis=1).reshape((-1,) + data.shape[1:])
-
-
-def zero_every_8th_complex(fh, data):
-    every_8th = (fh.tell() + np.arange(fh.samples_per_frame)) % 8 == 0
-    data[every_8th] = 0.
-    return data
-
-
-class TestFunctions:
-    """Test applying functions to Baseband's sample VDIF file."""
-
-    @pytest.mark.parametrize('function, sample_factor',
-                             ((zero_channel_4, 1.),
-                              (zero_every_8th_sample, 1.),
-                              (remove_every_other, 0.5),
-                              (double_data, 2.)))
-    def test_functions(self, function, sample_factor):
-        """Test setting a channel to zero."""
-
-        # Load baseband file and get reference intensities.
-        fh = vdif.open(SAMPLE_VDIF)
-        ref_data = function(fh.read())
-
-        ft = FunctionTask(fh, function,
-                          sample_rate=fh.sample_rate * sample_factor)
-
-        assert ft.shape[0] == fh.shape[0] * sample_factor
-        # Apply to everything.
-        data1 = ft.read()
-        assert ft.tell() == ft.shape[0]
-        assert (ft.time - ft.start_time -
-                ft.shape[0] / ft.sample_rate) < 1*u.ns
-        assert ft.dtype is ref_data.dtype is data1.dtype
-        assert np.allclose(ref_data, data1)
-
-        # Seeking and selective zeroing.
-        ft.seek(-3, 2)
-        assert ft.tell() == ft.shape[0] - 3
-        data2 = ft.read()
-        assert data2.shape[0] == 3
-        assert np.allclose(ref_data[-3:], data2)
-
-        ft.close()
-
-    @pytest.mark.parametrize('samples_per_frame', (None, 15, 1000))
-    def test_complex(self, samples_per_frame):
-        fh = vdif.open(SAMPLE_VDIF)
-        count = fh.shape[0]
-        if samples_per_frame is not None:
-            count = (count // samples_per_frame) * samples_per_frame
-        ref_data = zero_every_8th_sample(fh.read(count))
-
-        ft = ComplexFunctionTask(fh, zero_every_8th_complex,
-                                 samples_per_frame=samples_per_frame)
-
-        data1 = ft.read()
-
-        assert np.all(data1 == ref_data)
 
 
 class TestSquare:
@@ -97,7 +21,7 @@ class TestSquare:
         ref_data = fh.read()
         ref_data = np.real(ref_data * np.conj(ref_data))
 
-        st = SquareTask(fh)
+        st = Square(fh)
 
         # Square everything.
         data1 = st.read()
@@ -122,13 +46,13 @@ class TestSquare:
         # (Note: sideband is incorrect; just for testing purposes)
         fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 2) * 16. * u.MHz
         fh.sideband = np.tile([-1, +1], 4)
-        st = SquareTask(fh)
+        st = Square(fh)
         assert np.all(st.frequency == fh.frequency)
         assert np.all(st.sideband == st.sideband)
 
     def test_missing_frequency_sideband(self):
         fh = vdif.open(SAMPLE_VDIF)
-        st = SquareTask(fh)
+        st = Square(fh)
         with pytest.raises(AttributeError):
             st.frequency
         with pytest.raises(AttributeError):

--- a/scintillometry/tests/test_generators.py
+++ b/scintillometry/tests/test_generators.py
@@ -5,7 +5,8 @@ import astropy.units as u
 from astropy.time import Time
 
 from ..generators import StreamGenerator, EmptyStreamGenerator, NoiseGenerator
-from ..functions import FunctionTask, SquareTask
+from ..functions import Square
+from ..base import Task
 
 
 class StreamBase:
@@ -101,7 +102,7 @@ class TestConstant(StreamBase):
         with EmptyStreamGenerator(
                 shape=self.shape, start_time=self.start_time,
                 sample_rate=self.sample_rate, samples_per_frame=20) as eh, \
-                FunctionTask(eh, set_constant) as sh:
+                Task(eh, set_constant) as sh:
             assert sh.size == np.prod(self.shape)
             assert sh.shape == self.shape
             assert sh.samples_per_frame == 20
@@ -122,7 +123,7 @@ class TestConstant(StreamBase):
         with EmptyStreamGenerator(
                 shape=(10, 1000), start_time=self.start_time,
                 sample_rate=10. * u.Hz, samples_per_frame=2) as eh, \
-                FunctionTask(eh, set_tone) as sh:
+                Task(eh, set_tone) as sh:
             assert abs(sh.stop_time - sh.start_time - 1. * u.s) < 1. * u.ns
             sh.seek(5)
             data1 = sh.read(1)
@@ -143,7 +144,7 @@ class TestConstant(StreamBase):
         with EmptyStreamGenerator(
                 shape=(10, 1000), start_time=self.start_time,
                 sample_rate=10. * u.Hz, samples_per_frame=2) as eh, \
-                FunctionTask(eh, set_tone) as sh:
+                Task(eh, set_tone) as sh:
             assert sh.samples_per_frame == 2
             assert abs(sh.stop_time - sh.start_time - 1. * u.s) < 1. * u.ns
             sh.seek(4)
@@ -164,8 +165,8 @@ class TestConstant(StreamBase):
 
         eh = EmptyStreamGenerator(shape=(10, 1000), start_time=self.start_time,
                                   sample_rate=10. * u.Hz, samples_per_frame=2)
-        sh = FunctionTask(eh, set_tone)
-        st = SquareTask(sh)
+        sh = Task(eh, set_tone)
+        st = Square(sh)
         data1 = st.read()
         assert st.tell() == st.shape[0]
         assert abs(st.time - st.start_time - 1. * u.s) < 1*u.ns
@@ -240,7 +241,7 @@ class TestNoise:
                             shape=self.shape, start_time=self.start_time,
                             sample_rate=self.sample_rate,
                             samples_per_frame=10, dtype=np.complex128)
-        st = SquareTask(nh)
+        st = Square(nh)
         assert st.dtype == np.dtype('f8')
         data1 = st.read()
         assert st.tell() == st.shape[0]


### PR DESCRIPTION
Get rid of all `Task` postfixes, and have a single `Task` class that can take either a function or a method like callable.