### PR TITLE
Add a Power task, which squares while keeping polarization cross-products

### DIFF
--- a/scintillometry/functions.py
+++ b/scintillometry/functions.py
@@ -4,19 +4,30 @@ import numpy as np
 from .base import TaskBase
 
 
-__all__ = ['Square']
+__all__ = ['Square', 'Power']
 
 
 class Square(TaskBase):
     """Converts samples to intensities by squaring.
 
+    Note that `Square` does not keep full polarization information;
+    it simply calculates the power for each polarization.  Use
+    `~scintillometry.functions.Power` to also calculate cross products.
+
     Parameters
     ----------
     ih : task or `baseband` stream reader
         Input data stream.
+    polarization : array or (nested) list of char, optional
+        Polarization labels.  Should broadcast to the sample shape,
+        i.e., the labels are in the correct axis.  For instance,
+        ``['X', 'Y']``, or ``[['L'], ['R']]``.  By default, taken
+        from the underlying stream (and ignored if not given).
+        Output labels will have the polarization labels doubled,
+        i.e., ``['XX', 'YY']``, ``[['LL'], ['RR']]``, etc.
     """
 
-    def __init__(self, ih):
+    def __init__(self, ih, polarization=None):
         ih_dtype = np.dtype(ih.dtype)
         if ih_dtype.kind != 'c':
             square = np.square
@@ -26,4 +37,77 @@ class Square(TaskBase):
 
         self.task = square
         dtype = self.task(np.zeros(1, dtype=ih_dtype)).dtype
-        super().__init__(ih, dtype=dtype)
+        super().__init__(ih, dtype=dtype, polarization=polarization)
+        if self._polarization is not None:
+            self._polarization = np.core.defchararray.add(
+                self._polarization, self._polarization)
+
+
+class Power(TaskBase):
+    """Calculate powers and cross terms for two polarizations.
+
+    For polarizations X and Y, 4 terms are produced:
+
+    ==== ========= =========================
+    Term Value     Expanded
+    ==== ========= =========================
+    XX   Re(X X*)  Re(X)**2 + Im(X)**2
+    XY   Re(X Y*)  Re(X)*Re(Y) + Im(X)*Im(Y)
+    YX   Im(X Y*)  Im(X)*Re(Y) - Re(X)*Im(Y)
+    YY   Re(Y Y*)  Re(Y)**2 + Im(Y)**2
+    ==== ========= =========================
+
+    Parameters
+    ----------
+    ih : task or `baseband` stream reader
+        Input data stream.
+    polarization : array or (nested) list of char, optional
+        Polarization labels.  Should broadcast to the sample shape,
+        i.e., the labels are in the correct axis.  For instance,
+        ``['X', 'Y']``, or ``[['L'], ['R']]``.  By default, taken
+        from the underlying stream.
+
+    Raises
+    ------
+    AttributeError
+        If no polarization information is given.
+    ValueError
+        If the underlying stream is not complex, the number of polarizations
+        not equal to two, or the polarization labels not unique.
+    """
+    def __init__(self, ih, polarization=None):
+        ih_dtype = np.dtype(ih.dtype)
+        if ih_dtype.kind != 'c':
+            raise ValueError("{} only works on a complex timestream.")
+        dtype = np.zeros(1, ih_dtype).real.dtype
+        super().__init__(ih, polarization=polarization, dtype=dtype)
+        polarization = self.polarization
+        if polarization.size != 2:
+            raise ValueError("need exactly 2 polarizations.  Reshape stream "
+                             "appropriately.")
+        pol_axis = polarization.shape.index(2)
+        polarization = polarization.swapaxes(0, pol_axis)
+        if polarization[0] == polarization[1]:
+            raise ValueError("need 2 unique polarizations.")
+
+        polarization = np.core.defchararray.add(polarization[[0, 0, 1, 1]],
+                                                polarization[[0, 1, 0, 1]])
+        self._polarization = polarization.swapaxes(0, pol_axis)
+        self._axis = ih.ndim - polarization.ndim + pol_axis
+        self._shape = self._shape[:self._axis] + (4,) + self._shape[self._axis+1:]
+
+    def task(self, data):
+        """Calculate the polarization powers and cross terms for one frame."""
+        result = np.empty(data.shape[:1] + self.shape[1:], self.dtype)
+        # Get views in which the axis with the polarization is first.
+        in_ = data.swapaxes(0, self._axis)
+        out = result.swapaxes(0, self._axis)
+        r0 = in_[0].real
+        i0 = in_[0].imag
+        r1 = in_[1].real
+        i1 = in_[1].imag
+        out[0] = r0 ** 2 + i0 ** 2
+        out[1] = r0 * r1 + i0 * i1
+        out[2] = i0 * r1 - r0 * i1
+        out[3] = r1 ** 2 + i1 ** 2
+        return result

--- a/scintillometry/functions.py
+++ b/scintillometry/functions.py
@@ -48,14 +48,14 @@ class Power(TaskBase):
 
     For polarizations X and Y, 4 terms are produced:
 
-    ==== ========= =========================
-    Term Value     Expanded
-    ==== ========= =========================
-    XX   Re(X X*)  Re(X)**2 + Im(X)**2
-    XY   Re(X Y*)  Re(X)*Re(Y) + Im(X)*Im(Y)
-    YX   Im(X Y*)  Im(X)*Re(Y) - Re(X)*Im(Y)
-    YY   Re(Y Y*)  Re(Y)**2 + Im(Y)**2
-    ==== ========= =========================
+    ==== ========= ========================= ==========
+    Term Value     Expanded                  Other name
+    ==== ========= ========================= ==========
+    XX   Re(X X*)  Re(X)**2 + Im(X)**2       AA
+    YY   Re(Y Y*)  Re(Y)**2 + Im(Y)**2       BB
+    XY   Re(X Y*)  Re(X)*Re(Y) + Im(X)*Im(Y) CR
+    YX   Im(X Y*)  Im(X)*Re(Y) - Re(X)*Im(Y) CI
+    ==== ========= ========================= ==========
 
     Parameters
     ----------
@@ -90,8 +90,8 @@ class Power(TaskBase):
         if polarization[0] == polarization[1]:
             raise ValueError("need 2 unique polarizations.")
 
-        polarization = np.core.defchararray.add(polarization[[0, 0, 1, 1]],
-                                                polarization[[0, 1, 0, 1]])
+        polarization = np.core.defchararray.add(polarization[[0, 1, 0, 1]],
+                                                polarization[[0, 1, 1, 0]])
         self._polarization = polarization.swapaxes(0, pol_axis)
         self._axis = ih.ndim - polarization.ndim + pol_axis
         self._shape = self._shape[:self._axis] + (4,) + self._shape[self._axis+1:]
@@ -107,7 +107,7 @@ class Power(TaskBase):
         r1 = in_[1].real
         i1 = in_[1].imag
         out[0] = r0 ** 2 + i0 ** 2
-        out[1] = r0 * r1 + i0 * i1
-        out[2] = i0 * r1 - r0 * i1
-        out[3] = r1 ** 2 + i1 ** 2
+        out[1] = r1 ** 2 + i1 ** 2
+        out[2] = r0 * r1 + i0 * i1
+        out[3] = i0 * r1 - r0 * i1
         return result

--- a/scintillometry/tests/test_functions.py
+++ b/scintillometry/tests/test_functions.py
@@ -70,12 +70,12 @@ class TestPower:
         ref_data = fh.read()
         r0, i0, r1, i1 = ref_data.view('f4').T
         ref_data = np.stack((r0 * r0 + i0 * i0,
+                             r1 * r1 + i1 * i1,
                              r0 * r1 + i0 * i1,
-                             i0 * r1 - r0 * i1,
-                             r1 * r1 + i1 * i1), axis=1)
+                             i0 * r1 - r0 * i1), axis=1)
 
         pt = Power(fh, polarization=['L', 'R'])
-        assert np.all(pt.polarization == np.array(['LL', 'LR', 'RL', 'RR']))
+        assert np.all(pt.polarization == np.array(['LL', 'RR', 'LR', 'RL']))
 
         # Square everything.
         data1 = pt.read()
@@ -90,7 +90,7 @@ class TestPower:
         # (Note: sideband is incorrect; just for testing purposes)
         fh.polarization = np.array(['L', 'R'])
         pt = Power(fh)
-        assert np.all(pt.polarization == np.array(['LL', 'LR', 'RL', 'RR']))
+        assert np.all(pt.polarization == np.array(['LL', 'RR', 'LR', 'RL']))
 
     def test_missing_polarization(self):
         fh = dada.open(SAMPLE_DADA)

--- a/scintillometry/tests/test_functions.py
+++ b/scintillometry/tests/test_functions.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import astropy.units as u
 
-from ..functions import Square
+from ..functions import Square, Power
 
 from baseband import vdif, dada
 from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
@@ -13,9 +13,7 @@ from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
 class TestSquare:
     """Test getting simple intensities using Baseband's sample DADA file."""
 
-    def test_squaretask(self):
-        """Test squarer."""
-
+    def test_square(self):
         # Load baseband file and get reference intensities.
         fh = dada.open(SAMPLE_DADA)
         ref_data = fh.read()
@@ -46,14 +44,68 @@ class TestSquare:
         # (Note: sideband is incorrect; just for testing purposes)
         fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 2) * 16. * u.MHz
         fh.sideband = np.tile([-1, +1], 4)
+        fh.polarization = np.tile(['L', 'R'], 4)
         st = Square(fh)
         assert np.all(st.frequency == fh.frequency)
-        assert np.all(st.sideband == st.sideband)
+        assert np.all(st.sideband == fh.sideband)
+        assert np.all(st.polarization == np.tile(['LL', 'RR'], 4))
 
-    def test_missing_frequency_sideband(self):
+    def test_missing_frequency_sideband_polarization(self):
         fh = vdif.open(SAMPLE_VDIF)
         st = Square(fh)
         with pytest.raises(AttributeError):
             st.frequency
         with pytest.raises(AttributeError):
             st.sideband
+        with pytest.raises(AttributeError):
+            st.polarization
+
+
+class TestPower:
+    """Test getting polarized intensities using Baseband's sample DADA file."""
+
+    def test_power(self):
+        # Load baseband file and get reference intensities.
+        fh = dada.open(SAMPLE_DADA)
+        ref_data = fh.read()
+        r0, i0, r1, i1 = ref_data.view('f4').T
+        ref_data = np.stack((r0 * r0 + i0 * i0,
+                             r0 * r1 + i0 * i1,
+                             i0 * r1 - r0 * i1,
+                             r1 * r1 + i1 * i1), axis=1)
+
+        pt = Power(fh, polarization=['L', 'R'])
+        assert np.all(pt.polarization == np.array(['LL', 'LR', 'RL', 'RR']))
+
+        # Square everything.
+        data1 = pt.read()
+        assert (pt.time - fh.start_time -
+                fh.shape[0] / fh.sample_rate) < 1*u.ns
+        assert pt.dtype is ref_data.dtype is data1.dtype
+        assert np.allclose(ref_data, data1)
+
+    def test_polarization_propagation(self):
+        fh = dada.open(SAMPLE_DADA)
+        # Add frequency and sideband information by hand.
+        # (Note: sideband is incorrect; just for testing purposes)
+        fh.polarization = np.array(['L', 'R'])
+        pt = Power(fh)
+        assert np.all(pt.polarization == np.array(['LL', 'LR', 'RL', 'RR']))
+
+    def test_missing_polarization(self):
+        fh = dada.open(SAMPLE_DADA)
+        with pytest.raises(AttributeError):
+            Power(fh)
+
+    def test_wrong_polarization(self):
+        fh = dada.open(SAMPLE_DADA)
+        with pytest.raises(ValueError):
+            Power(fh, polarization=['L'])
+        with pytest.raises(ValueError):
+            Power(fh, polarization=[['L'], ['R']])
+        with pytest.raises(ValueError):
+            Power(fh, polarization=[['L'], ['L']])
+
+        fh = vdif.open(SAMPLE_VDIF)
+        with pytest.raises(ValueError):
+            Power(fh)


### PR DESCRIPTION
This one keeps cross-terms, following what appears to be standard convention (from `scintellometry`).

@luojing1211 - could you have a look?