### PR TITLE
Auto integrator

### DIFF
--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -126,20 +126,20 @@ class Fold(Base):
 
     .. warning: The format for ``average=False`` may change in the future.
     """
-    def __init__(self, ih, n_phase, phase, fold_time=None, average=True,
+    def __init__(self, ih, n_phase, phase, sample_time=None, average=True,
                  samples_per_frame=1, dtype=None):
         self.ih = ih
         self.n_phase = n_phase
         total_time = ih.stop_time - ih.start_time
-        if fold_time is None:
-            fold_time = total_time
-        self.fold_time = fold_time
+        if sample_time is None:
+            sample_time = total_time
+        self.sample_time = sample_time
         self.phase = phase
         self.average = average
 
         # Note that there may be some time at the end that is never used.
         # Might want to include it if, e.g., it is more than half used.
-        nsample = int((total_time / self.fold_time).to_value(u.one) //
+        nsample = int((total_time / self.sample_time).to_value(u.one) //
                       samples_per_frame) * samples_per_frame
         shape = (nsample, n_phase) + ih.shape[1:]
         # This probably should be moved to a better base class; unfortunately,
@@ -155,7 +155,7 @@ class Fold(Base):
                 dtype = np.dtype([('data', ih.dtype), ('count', int)])
 
         super().__init__(shape=shape, start_time=ih.start_time,
-                         sample_rate=1./fold_time,
+                         sample_rate=1./sample_time,
                          samples_per_frame=samples_per_frame,
                          frequency=frequency, sideband=sideband,
                          polarization=polarization, dtype=dtype)
@@ -181,8 +181,8 @@ class Fold(Base):
 
         # Get sample and phase indices.
         time_offset = np.arange(n_raw) / self.ih.sample_rate
-        sample_index = (time_offset /
-                        self.fold_time).to_value(u.one).astype(int)
+        sample_index = (time_offset *
+                        self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.
         phases = self.phase(raw_time + time_offset)
         phase_index = ((phases.to_value(u.one) * self.n_phase)

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -227,8 +227,11 @@ class Fold(IntegrateBase):
         assert type(item) is slice
         # Get sample and phase indices.
         time_offset = np.arange(item.start, item.stop) / self.ih.sample_rate
-        sample_index = (time_offset *
-                        self.sample_rate).to_value(u.one).astype(int)
+        if self.samples_per_frame == 1:
+            sample_index = 0
+        else:
+            sample_index = (time_offset *
+                            self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.
         phases = self.phase(self._raw_time + time_offset)
         phase_index = ((phases.to_value(u.one) * self.n_phase)

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -10,7 +10,43 @@ from .base import Base
 __all__ = ['Integrate', 'Fold']
 
 
-class Integrate(Base):
+class IntegrateBase(Base):
+    """Base class for integrations over fixed sample times."""
+
+    def __init__(self, ih, sample_time=None, average=True,
+                 samples_per_frame=1, sample_shape=None, dtype=None):
+        self.ih = ih
+        self.average = average
+
+        total_time = ih.stop_time - ih.start_time
+        if sample_time is None:
+            sample_time = total_time
+
+        nsample = int((total_time / sample_time).to_value(1) //
+                      samples_per_frame) * samples_per_frame
+        if sample_shape is None:
+            sample_shape = ih.sample_shape
+        shape = (nsample,) + sample_shape
+
+        if dtype is None:
+            if average:
+                dtype = ih.dtype
+            else:
+                dtype = np.dtype([('data', ih.dtype), ('count', int)])
+
+        frequency = getattr(ih, 'frequency', None)
+        sideband = getattr(ih, 'sideband', None)
+        polarization = getattr(ih, 'polarization', None)
+
+        super().__init__(start_time=ih.start_time,
+                         shape=shape, sample_rate=1./sample_time,
+                         samples_per_frame=samples_per_frame,
+                         frequency=frequency, sideband=sideband,
+                         polarization=polarization, dtype=dtype)
+        self._raw_samples_per_frame = samples_per_frame * sample_time
+
+
+class Integrate(IntegrateBase):
     """Integrate a stream over specific time steps.
 
     Parameters
@@ -42,34 +78,15 @@ class Integrate(Base):
     """
 
     def __init__(self, ih, sample_time=None, average=True, dtype=None):
-        self.ih = ih
-        self.average = average
-        total_time = ih.stop_time - ih.start_time
-        if sample_time is None:
-            sample_time = total_time
-        nsample = int((total_time / sample_time).to_value(1))
-
-        shape = (nsample,) + ih.shape[1:]
-        frequency = getattr(ih, 'frequency', None)
-        sideband = getattr(ih, 'sideband', None)
-        polarization = getattr(ih, 'polarization', None)
-        if dtype is None:
-            if self.average:
-                dtype = ih.dtype
-            else:
-                dtype = np.dtype([('data', ih.dtype), ('count', int)])
-
-        super().__init__(start_time=ih.start_time,
-                         shape=shape, sample_rate=1./sample_time,
-                         samples_per_frame=1, frequency=frequency,
-                         sideband=sideband, polarization=polarization,
-                         dtype=dtype)
+        super().__init__(ih, sample_time=sample_time, average=average, dtype=dtype)
 
     def _read_frame(self, frame_index):
-        raw_stop = self.ih.seek((frame_index + 1) / self.sample_rate)
-        raw_start = self.ih.seek(frame_index / self.sample_rate)
+        # Determine which raw samples to read, and read them.
+        # Note: self._raw_samples_per_frame can have units of time.
+        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
+        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
         data = self.ih.read(raw_stop - raw_start)
-        out = np.zeros((self.samples_per_frame,) + self.shape[1:],
+        out = np.zeros((self.samples_per_frame,) + self.sample_shape,
                        dtype=self.dtype)
         if self.average:
             result = out
@@ -85,7 +102,7 @@ class Integrate(Base):
         return out
 
 
-class Fold(Base):
+class Fold(IntegrateBase):
     """Fold pulse profiles in fixed time intervals.
 
     Parameters
@@ -128,48 +145,23 @@ class Fold(Base):
     """
     def __init__(self, ih, n_phase, phase, sample_time=None, average=True,
                  samples_per_frame=1, dtype=None):
-        self.ih = ih
         self.n_phase = n_phase
-        total_time = ih.stop_time - ih.start_time
-        if sample_time is None:
-            sample_time = total_time
-        self.sample_time = sample_time
         self.phase = phase
-        self.average = average
 
-        # Note that there may be some time at the end that is never used.
-        # Might want to include it if, e.g., it is more than half used.
-        nsample = int((total_time / self.sample_time).to_value(u.one) //
-                      samples_per_frame) * samples_per_frame
-        shape = (nsample, n_phase) + ih.shape[1:]
-        # This probably should be moved to a better base class; unfortunately,
-        # we cannot use TaskBase since it does not allow non-integer sample
-        # rate ratios.
-        frequency = getattr(ih, 'frequency', None)
-        sideband = getattr(ih, 'sideband', None)
-        polarization = getattr(ih, 'polarization', None)
-        if dtype is None:
-            if self.average:
-                dtype = ih.dtype
-            else:
-                dtype = np.dtype([('data', ih.dtype), ('count', int)])
-
-        super().__init__(shape=shape, start_time=ih.start_time,
-                         sample_rate=1./sample_time,
-                         samples_per_frame=samples_per_frame,
-                         frequency=frequency, sideband=sideband,
-                         polarization=polarization, dtype=dtype)
+        super().__init__(ih, sample_time=sample_time, average=average,
+                         sample_shape=(n_phase,) + ih.sample_shape,
+                         samples_per_frame=samples_per_frame, dtype=dtype)
 
     def _read_frame(self, frame_index):
         # Determine which raw samples to read, and read them.
-        frame_rate = self.sample_rate / self.samples_per_frame
-        raw_stop = self.ih.seek((frame_index + 1) / frame_rate)
-        raw_start = self.ih.seek(frame_index / frame_rate)
+        # Note: self._raw_samples_per_frame can have units of time.
+        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
+        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
         raw_time = self.ih.time
         n_raw = raw_stop - raw_start
         raw = self.ih.read(n_raw)
         # Set up output arrays.
-        out = np.zeros((self.samples_per_frame,) + self.shape[1:],
+        out = np.zeros((self.samples_per_frame,) + self.sample_shape,
                        dtype=self.dtype)
         if self.average:
             result = out

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -10,6 +10,15 @@ from .base import Base
 __all__ = ['Integrate', 'Fold']
 
 
+class _IntegratorCallBack:
+    def __init__(self, shape, setitem):
+        self.shape = shape
+        self.setitem = setitem
+
+    def __setitem__(self, item, value):
+        return self.setitem(item, value)
+
+
 class IntegrateBase(Base):
     """Base class for integrations over fixed sample times."""
 
@@ -85,21 +94,27 @@ class Integrate(IntegrateBase):
         # Note: self._raw_samples_per_frame can have units of time.
         raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
         raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
-        data = self.ih.read(raw_stop - raw_start)
+        n_raw = raw_stop - raw_start
         out = np.zeros((self.samples_per_frame,) + self.sample_shape,
                        dtype=self.dtype)
         if self.average:
-            result = out
-            count = np.zeros(result.shape[:1] + (1,) * (result.ndim - 1),
-                             dtype=int)
+            self._result = out
+            self._count = np.zeros(out.shape[:1] + (1,) * (out.ndim - 1),
+                                   dtype=int)
         else:
-            result = out['data']
-            count = out['count']
-        result[:] = data.sum(0, keepdims=True)
-        count[:] = len(data)
+            self._result = out['data']
+            self._count = out['count']
+        fake_out = _IntegratorCallBack((n_raw,) + self.ih.sample_shape,
+                                       self._callback)
+        fake_out = self.ih.read(out=fake_out)
         if self.average:
-            out /= count
+            out /= self._count
         return out
+
+    def _callback(self, item, data):
+        assert type(item) is slice
+        self._result[:] += data.sum(0, keepdims=True)
+        self._count[:] += len(data)
 
 
 class Fold(IntegrateBase):
@@ -157,34 +172,38 @@ class Fold(IntegrateBase):
         # Note: self._raw_samples_per_frame can have units of time.
         raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
         raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
-        raw_time = self.ih.time
+        self._raw_time = self.ih.time
         n_raw = raw_stop - raw_start
-        raw = self.ih.read(n_raw)
         # Set up output arrays.
         out = np.zeros((self.samples_per_frame,) + self.sample_shape,
                        dtype=self.dtype)
         if self.average:
-            result = out
-            count = np.zeros(result.shape[:2] + (1,) * (result.ndim - 2),
-                             dtype=int)
+            self._result = out
+            self._count = np.zeros(out.shape[:2] + (1,) * (out.ndim - 2),
+                                   dtype=int)
         else:
-            result = out['data']
-            count = out['count']
+            self._result = out['data']
+            self._count = out['count']
 
+        fake_out = _IntegratorCallBack((n_raw,) + self.ih.sample_shape,
+                                       self._callback)
+        fake_out = self.ih.read(out=fake_out)
+        if self.average:
+            out /= self._count
+
+        return out
+
+    def _callback(self, item, raw):
+        assert type(item) is slice
         # Get sample and phase indices.
-        time_offset = np.arange(n_raw) / self.ih.sample_rate
+        time_offset = np.arange(item.start, item.stop) / self.ih.sample_rate
         sample_index = (time_offset *
                         self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.
-        phases = self.phase(raw_time + time_offset)
+        phases = self.phase(self._raw_time + time_offset)
         phase_index = ((phases.to_value(u.one) * self.n_phase)
                        % self.n_phase).astype(int)
         # Do the actual folding, adding the data to the sums and counts.
         # TODO: np.add.at is not very efficient; replace?
-        np.add.at(result, (sample_index, phase_index), raw)
-        np.add.at(count, (sample_index, phase_index), 1)
-
-        if self.average:
-            out /= count
-
-        return out
+        np.add.at(self._result, (sample_index, phase_index), raw)
+        np.add.at(self._count, (sample_index, phase_index), 1)

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -48,6 +48,7 @@ class IntegrateBase(Base):
 
         nsample = int((total_time / sample_time).to_value(1) //
                       samples_per_frame) * samples_per_frame
+        assert nsample > 0, "time per frame larger than total time in stream"
         if sample_shape is None:
             sample_shape = ih.sample_shape
         shape = (nsample,) + sample_shape

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -7,7 +7,82 @@ import astropy.units as u
 from .base import Base
 
 
-__all__ = ['Fold']
+__all__ = ['Integrate', 'Fold']
+
+
+class Integrate(Base):
+    """Integrate a stream over specific time steps.
+
+    Parameters
+    ----------
+    ih : task or `baseband` stream reader
+        Input data stream, with time as the first axis.
+    sample_time : `~astropy.units.Quantity`, optional
+        With units of time.  By default, will integrate the whole input stream.
+    average : bool, optional
+        Whether to calculate sums (with a ``count`` attribute) or to average
+        values.
+    dtype : `~numpy.dtype`, optional
+        Output dtype.  Generally, the default of the dtype of the underlying
+        stream is good enough, but can be used to increase precision.  Note
+        that if ``average=True``, it is the user's responsibilty to pass in
+        a structured dtype.
+
+    Notes
+    -----
+    Since the sample time is not necessarily an integer multiple of the pulse
+    period, the returned profiles will generally not contain the same number
+    of samples in each phase bin.  The actual number of samples is counted,
+    and for ``average=True``, the sums have been divided by these counts, with
+    bins with no points set to ``NaN``.  For ``average=False``, the arrays
+    returned by ``read`` are structured arrays with ``data`` and ``count``
+    fields.
+
+    .. warning: The format for ``average=False`` may change in the future.
+    """
+
+    def __init__(self, ih, sample_time=None, average=True, dtype=None):
+        self.ih = ih
+        self.average = average
+        total_time = ih.stop_time - ih.start_time
+        if sample_time is None:
+            sample_time = total_time
+        nsample = int((total_time / sample_time).to_value(1))
+
+        shape = (nsample,) + ih.shape[1:]
+        frequency = getattr(ih, 'frequency', None)
+        sideband = getattr(ih, 'sideband', None)
+        polarization = getattr(ih, 'polarization', None)
+        if dtype is None:
+            if self.average:
+                dtype = ih.dtype
+            else:
+                dtype = np.dtype([('data', ih.dtype), ('count', int)])
+
+        super().__init__(start_time=ih.start_time,
+                         shape=shape, sample_rate=1./sample_time,
+                         samples_per_frame=1, frequency=frequency,
+                         sideband=sideband, polarization=polarization,
+                         dtype=dtype)
+
+    def _read_frame(self, frame_index):
+        raw_stop = self.ih.seek((frame_index + 1) / self.sample_rate)
+        raw_start = self.ih.seek(frame_index / self.sample_rate)
+        data = self.ih.read(raw_stop - raw_start)
+        out = np.zeros((self.samples_per_frame,) + self.shape[1:],
+                       dtype=self.dtype)
+        if self.average:
+            result = out
+            count = np.zeros(result.shape[:1] + (1,) * (result.ndim - 1),
+                             dtype=int)
+        else:
+            result = out['data']
+            count = out['count']
+        result[:] = data.sum(0, keepdims=True)
+        count[:] = len(data)
+        if self.average:
+            out /= count
+        return out
 
 
 class Fold(Base):
@@ -23,7 +98,7 @@ class Fold(Base):
         Should return pulse phases for given input time(s), passed in as an
         '~astropy.time.Time' object.  The output should be an array of float;
         the phase can include the cycle count.
-    fold_time : `~astropy.units.Quantity`, optional
+    sample_time : `~astropy.units.Quantity`, optional
         Time interval over which to fold, i.e., the sample time of the output.
         If not given, the whole file will be folded into a single profile.
     average : bool, optional
@@ -31,7 +106,7 @@ class Fold(Base):
         that contributed to it, or rather the sum, in a structured array that
         holds both ``'data'`` and ``'count'`` items.
     samples_per_frame : int, optional
-        Number of fold times to process in one go.  This can be used to
+        Number of sample times to process in one go.  This can be used to
         optimize the process, though in general the default of 1 should work.
     dtype : `~numpy.dtype`, optional
         Output dtype.  Generally, the default of the dtype of the underlying
@@ -41,7 +116,7 @@ class Fold(Base):
 
     Notes
     -----
-    Since the fold time is not necessarily an integer multiple of the pulse
+    Since the sample time is not necessarily an integer multiple of the pulse
     period, the returned profiles will generally not contain the same number
     of samples in each phase bin.  The actual number of samples is counted,
     and for ``average=True``, the sums have been divided by these counts, with

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -230,6 +230,8 @@ class Fold(IntegrateBase):
         if self.samples_per_frame == 1:
             sample_index = 0
         else:
+            # This is not quite correct: should take into account possible
+            # time offset between self and underlying stream.
             sample_index = (time_offset *
                             self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -6,29 +6,52 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time
 
-from baseband.data import SAMPLE_DADA
-from baseband import dada
-
 from ..base import Task
 from ..generators import EmptyStreamGenerator
 from ..integration import Integrate, Fold
 from ..functions import Square
 
 
-class TestIntegrate:
+class TestFakePulsarBase:
+    def setup(self):
+        self.start_time = Time('2010-11-12T13:14:15')
+        self.sample_rate = 10. * u.kHz
+        self.shape = (16000, 2)
+        self.eh = EmptyStreamGenerator(shape=self.shape,
+                                       start_time=self.start_time,
+                                       sample_rate=self.sample_rate,
+                                       samples_per_frame=200, dtype=np.float)
+        self.sh = Task(self.eh, self.pulse_simulate)
+        self.period_bin = 125
+        self.F0 = 1.0 / (self.period_bin / self.sh.sample_rate)
+        self.n_phase = 50
+        self.raw_data = self.sh.read()
+        self.raw_power = np.abs(self.raw_data)**2
+        self.sh.seek(0)
+
+    def phase(self, t):
+        return self.F0 * (t - self.start_time)
+
+    def pulse_simulate(self, fh, data):
+        idx = fh.tell() + np.arange(data.shape[0])
+        result = np.where(idx % self.period_bin == 0, 10., 0.125)
+        result.shape = (-1,) + (1,) * (data.ndim - 1)
+        data[:] = result
+        return data
+
+
+class TestIntegrate(TestFakePulsarBase):
     """Test integrating intensities using Baseband's sample DADA file."""
 
     def test_integrate_all(self):
         # Load baseband file and get reference intensities.
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read()
-        ref_data = np.real(raw * np.conj(raw)).mean(0)
+        ref_data = self.raw_power.mean(0)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st)
-        assert ip.start_time == fh.start_time
-        assert abs(ip.stop_time - fh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - fh.start_time - 1./ip.sample_rate) < 1. * u.ns
+        assert ip.start_time == self.sh.start_time
+        assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
+        assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         data = ip.read()
@@ -39,15 +62,13 @@ class TestIntegrate:
 
     def test_integrate_all_no_average(self):
         # Load baseband file and get reference intensities.
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read()
-        ref_data = np.real(raw * np.conj(raw)).sum(0)
+        ref_data = self.raw_power.sum(0)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st, average=False)
-        assert ip.start_time == fh.start_time
-        assert abs(ip.stop_time - fh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - fh.start_time - 1./ip.sample_rate) < 1. * u.ns
+        assert ip.start_time == self.sh.start_time
+        assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
+        assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         integrated = ip.read()
@@ -57,26 +78,24 @@ class TestIntegrate:
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == (1, 2)
         assert np.allclose(data, ref_data)
-        assert np.all(count == fh.shape[0])
+        assert np.all(count == self.sh.shape[0])
 
     @pytest.mark.parametrize('samples_per_frame', (1, 4, 10))
     @pytest.mark.parametrize('n', (1, 3))
     def test_integrate_n(self, n, samples_per_frame):
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(10 * n)
-        ref_data = np.real(raw * np.conj(raw)).reshape(-1, n, 2).sum(1)
+        ref_data = self.raw_power[121 * n:131 * n].reshape(-1, n, 2).sum(1)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st, n, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n
 
-        # Square and integrate everything.
+        ip.seek(121)
         integrated = ip.read(10)
         data = integrated['data']
         count = integrated['count']
-        assert ip.tell() == 10
+        assert ip.tell() == 131
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == ref_data.shape
         assert np.allclose(data, ref_data)
@@ -85,21 +104,19 @@ class TestIntegrate:
     @pytest.mark.parametrize('samples_per_frame', (1, 4, 10))
     @pytest.mark.parametrize('n', (1, 3))
     def test_integrate_n_via_time(self, n, samples_per_frame):
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(10 * n)
-        ref_data = np.real(raw * np.conj(raw)).reshape(-1, n, 2).sum(1)
+        ref_data = self.raw_power[151*n:161*n].reshape(-1, n, 2).sum(1)
 
-        st = Square(fh)
-        ip = Integrate(st, n/fh.sample_rate, average=False,
+        st = Square(self.sh)
+        ip = Integrate(st, n/self.sh.sample_rate, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n
 
-        # Square and integrate everything.
+        ip.seek(151)
         integrated = ip.read(10)
         data = integrated['data']
         count = integrated['count']
-        assert ip.tell() == 10
+        assert ip.tell() == 161
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == ref_data.shape
         assert np.allclose(data, ref_data)
@@ -113,16 +130,14 @@ class TestIntegrate:
         # 3rd ..             4.52 - 6.78 -> 2 samples; etc.
         expected_count = [2, 3, 2, 2, 2, 3, 2, 2]
         n_sample = 2.26
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(18)
-        ref_data = np.add.reduceat(np.real(raw * np.conj(raw)),
-                                   np.add.accumulate([0] + expected_count[:-1]))
+        raw = self.raw_power[:18]
+        ref_data = np.add.reduceat(raw, np.add.accumulate([0] + expected_count[:-1]))
 
-        st = Square(fh)
-        ip = Integrate(st, n_sample / fh.sample_rate, average=False,
+        st = Square(self.sh)
+        ip = Integrate(st, n_sample / self.sh.sample_rate, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n_sample
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n_sample
 
         # Square and integrate everything.
         integrated = ip.read(8)
@@ -135,40 +150,14 @@ class TestIntegrate:
         assert np.all(count.T == expected_count)
 
     def test_time_too_large(self):
-        fh = dada.open(SAMPLE_DADA)
         with pytest.raises(AssertionError):
-            Integrate(fh, n_sample=1.*u.hr)
+            Integrate(self.sh, n_sample=1.*u.hr)
 
 
-class TestFoldBase:
-    def setup(self):
-        self.start_time = Time('2010-11-12T13:14:15')
-        self.sample_rate = 10. * u.kHz
-        self.shape = (6000, 2, 4)
-        self.eh = EmptyStreamGenerator(shape=self.shape,
-                                       start_time=self.start_time,
-                                       sample_rate=self.sample_rate,
-                                       samples_per_frame=200, dtype=np.float)
-        self.sh = Task(self.eh, self.pulse_simulate)
-        self.period_bin = 125
-        self.F0 = 1.0 / (self.period_bin / self.sh.sample_rate)
-        self.n_phase = 50
-
-    def phase(self, t):
-        return self.F0 * (t - self.start_time)
-
-    def pulse_simulate(self, fh, data):
-        idx = fh.tell() + np.arange(data.shape[0])
-        result = np.where(idx % self.period_bin == 0, 10., 0.125)
-        result.shape = (-1,) + (1,) * (data.ndim - 1)
-        data[:] = result
-        return data
-
-
-class TestFold(TestFoldBase):
+class TestFold(TestFakePulsarBase):
     def test_input_data(self):
-        indata = self.sh.read(1000)
-        pulses = np.where(indata[:, 0, 0] == 10)[0]
+        indata = self.raw_data[:1000]
+        pulses = np.where(indata[:, 0] == 10)[0]
         # Check if the input data is set up right.
         assert len(pulses) == 8, "Pulses are not simulated right."
 
@@ -207,7 +196,7 @@ class TestFold(TestFoldBase):
             "Folding counts vary more than expected."
         # Test the output on and off gates.
         ph0_bins = [0, 1, -1, -2]
-        pulse_power = np.sum(fr_data[:, ph0_bins, 0, 0], axis=1)
+        pulse_power = np.sum(fr_data[:, ph0_bins, 0], axis=1)
         assert 30 < pulse_power[0] < 33, \
             "Folded power of on-gate is incorrect."
 
@@ -231,7 +220,7 @@ class TestFold(TestFoldBase):
             "Average off-gate power is incorrect."
 
     def test_read_whole_file(self):
-        ref_data = self.sh.read()[:, 0, 0]
+        ref_data = self.raw_data[:, 0]
         phase = self.phase(self.start_time +
                            np.arange(self.sh.shape[0]) / self.sh.sample_rate)
         i_phase = ((phase * self.n_phase) % self.n_phase).astype(int)
@@ -242,7 +231,7 @@ class TestFold(TestFoldBase):
         fr = fh.read(1)
         assert np.all(fr[:, 2:-1] == 0.125), \
             "Average off-gate power is incorrect."
-        assert np.all(fr[0, :, 0, 0] == expected)
+        assert np.all(fr[0, :, 0] == expected)
 
     def test_time_too_large(self):
         with pytest.raises(AssertionError):

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -1,5 +1,5 @@
 # Licensed under the GPLv3 - see LICENSE
-"""Full-package tests of pulse folding."""
+"""Tests of integration and pulse folding."""
 
 import pytest
 import numpy as np
@@ -113,9 +113,9 @@ class TestFold(TestFoldBase):
         # Check if the input data is set up right.
         assert len(pulses) == 8, "Pulses are not simulated right."
 
-    def test_fold_time_shorter_than_period(self):
-        fold_time = 11 * u.ms
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time,
+    def test_sample_time_shorter_than_period(self):
+        sample_time = 11 * u.ms
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time,
                   samples_per_frame=1, average=False)
         fh.seek(0)
         fr = fh.read(3)
@@ -127,16 +127,16 @@ class TestFold(TestFoldBase):
 
         # For each of the samples, check that the correct ones have not
         # gotten any data.
-        eff_n_phase = (fold_time * self.F0 * self.n_phase).to_value(1)
+        eff_n_phase = (sample_time * self.F0 * self.n_phase).to_value(1)
         for ii, count in enumerate(fr_count):
             n_count_0 = (count == 0).sum()
             assert np.isclose(self.n_phase - n_count_0, eff_n_phase, 1), \
                 ("Sample {} has the wrong number of zero-count phase bins"
                  .format(ii))
 
-    def test_fold_time_longer_than_period(self):
-        fold_time = 26 * u.ms
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time,
+    def test_sample_time_longer_than_period(self):
+        sample_time = 26 * u.ms
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time,
                   samples_per_frame=1, average=False)
         fh.seek(0)
         fr = fh.read(10)
@@ -157,7 +157,7 @@ class TestFold(TestFoldBase):
 
     def test_folding_with_averaging(self):
         # Test averaging
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time=26 * u.ms,
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time=26 * u.ms,
                   samples_per_frame=20, average=True)
         fh.seek(0)
         fr = fh.read(10)
@@ -165,8 +165,8 @@ class TestFold(TestFoldBase):
             "Average off-gate power is incorrect."
 
     def test_non_integer_sample_rate_ratio(self):
-        fold_time = (1./3.) * u.s
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time, average=True)
+        sample_time = (1./3.) * u.s
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time, average=True)
         fr = fh.read(1)
         assert np.all(fr[:, 2:-1] == 0.125), \
             "Average off-gate power is incorrect."


### PR DESCRIPTION
As we had it, the integration would try to get all the data points that needed to be integrated in one go, which is guaranteed to run out of memory for longer sample times.  Here, instead, I pass a fake output to the raw read, which adds elements in the right place.