### PR TITLE
Avoid comparing units with 'time'.

### DIFF
--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -212,7 +212,8 @@ class Base:
         if unit is None:
             return self.offset
 
-        if unit == 'time':
+        # "isinstance" avoids costly comparisons of an actual unit with 'time'.
+        if not isinstance(unit, u.UnitBase) and unit == 'time':
             return self.start_time + self.tell(unit=u.s)
 
         return (self.offset / self.sample_rate).to(unit)


### PR DESCRIPTION
Comparing a unit with something else will invoke an attempt to interpret something else as a unit, which is very costly.