### PR TITLE
Ensure generators can count on offset being correct in _read_frame.

### DIFF
--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -266,6 +266,9 @@ class Base:
                                                 self._samples_per_frame)
 
             if frame_index != self._frame_index:
+                # Read the frame required.  Set offset at the start so
+                # that _read_frame can count on tell() being correct.
+                self.offset = frame_index * self._samples_per_frame
                 self._frame = self._read_frame(frame_index)
                 self._frame_index = frame_index
 

--- a/scintillometry/tests/test_generators.py
+++ b/scintillometry/tests/test_generators.py
@@ -206,9 +206,10 @@ class TestNoise:
             assert data.shape == nh.shape
             # Check repeatability.
             assert np.all(data1 == data[10:12])
-            nh.seek(10)
-            data2 = nh.read(2)
-            assert np.all(data2 == data[10:12])
+            # On purpose read over a frame boundary; gh-52.
+            nh.seek(9)
+            data2 = nh.read(3)
+            assert np.all(data2 == data[9:12])
             nh.seek(9000)
             data3 = nh.read()
             assert np.all(data3 == data[9000:])


### PR DESCRIPTION
Found while writing phase folding tests.