### PR TITLE
Integration by phase and its use in Stack

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ classes that can be linked together into a data reduction pipeline.
    tasks/dispersion
    tasks/channelize
    tasks/functions
+   tasks/integration
    tasks/shaping
    tasks/base
 

--- a/docs/tasks/integration.rst
+++ b/docs/tasks/integration.rst
@@ -1,0 +1,16 @@
+.. _integration:
+
+******************************************
+Integration (`scintillometry.integration`)
+******************************************
+
+`~scintillometry.integration` contains tasks for integration, folding, and
+craating pulse stacks.
+
+.. _integration_api:
+
+Reference/API
+=============
+
+.. automodapi:: scintillometry.integration
+   :no-inherited-members:

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -7,7 +7,82 @@ import astropy.units as u
 from .base import BaseTaskBase
 
 
-__all__ = ['Fold']
+__all__ = ['Integrate', 'Fold']
+
+
+class Integrate(Base):
+    """Integrate a stream over specific time steps.
+
+    Parameters
+    ----------
+    ih : task or `baseband` stream reader
+        Input data stream, with time as the first axis.
+    sample_time : `~astropy.units.Quantity`, optional
+        With units of time.  By default, will integrate the whole input stream.
+    average : bool, optional
+        Whether to calculate sums (with a ``count`` attribute) or to average
+        values.
+    dtype : `~numpy.dtype`, optional
+        Output dtype.  Generally, the default of the dtype of the underlying
+        stream is good enough, but can be used to increase precision.  Note
+        that if ``average=True``, it is the user's responsibilty to pass in
+        a structured dtype.
+
+    Notes
+    -----
+    Since the sample time is not necessarily an integer multiple of the pulse
+    period, the returned profiles will generally not contain the same number
+    of samples in each phase bin.  The actual number of samples is counted,
+    and for ``average=True``, the sums have been divided by these counts, with
+    bins with no points set to ``NaN``.  For ``average=False``, the arrays
+    returned by ``read`` are structured arrays with ``data`` and ``count``
+    fields.
+
+    .. warning: The format for ``average=False`` may change in the future.
+    """
+
+    def __init__(self, ih, sample_time=None, average=True, dtype=None):
+        self.ih = ih
+        self.average = average
+        total_time = ih.stop_time - ih.start_time
+        if sample_time is None:
+            sample_time = total_time
+        nsample = int((total_time / sample_time).to_value(1))
+
+        shape = (nsample,) + ih.shape[1:]
+        frequency = getattr(ih, 'frequency', None)
+        sideband = getattr(ih, 'sideband', None)
+        polarization = getattr(ih, 'polarization', None)
+        if dtype is None:
+            if self.average:
+                dtype = ih.dtype
+            else:
+                dtype = np.dtype([('data', ih.dtype), ('count', int)])
+
+        super().__init__(start_time=ih.start_time,
+                         shape=shape, sample_rate=1./sample_time,
+                         samples_per_frame=1, frequency=frequency,
+                         sideband=sideband, polarization=polarization,
+                         dtype=dtype)
+
+    def _read_frame(self, frame_index):
+        raw_stop = self.ih.seek((frame_index + 1) / self.sample_rate)
+        raw_start = self.ih.seek(frame_index / self.sample_rate)
+        data = self.ih.read(raw_stop - raw_start)
+        out = np.zeros((self.samples_per_frame,) + self.shape[1:],
+                       dtype=self.dtype)
+        if self.average:
+            result = out
+            count = np.zeros(result.shape[:1] + (1,) * (result.ndim - 1),
+                             dtype=int)
+        else:
+            result = out['data']
+            count = out['count']
+        result[:] = data.sum(0, keepdims=True)
+        count[:] = len(data)
+        if self.average:
+            out /= count
+        return out
 
 
 class Fold(BaseTaskBase):
@@ -23,7 +98,7 @@ class Fold(BaseTaskBase):
         Should return pulse phases for given input time(s), passed in as an
         '~astropy.time.Time' object.  The output should be an array of float;
         the phase can include the cycle count.
-    fold_time : `~astropy.units.Quantity`, optional
+    sample_time : `~astropy.units.Quantity`, optional
         Time interval over which to fold, i.e., the sample time of the output.
         If not given, the whole file will be folded into a single profile.
     average : bool, optional
@@ -31,7 +106,7 @@ class Fold(BaseTaskBase):
         that contributed to it, or rather the sum, in a structured array that
         holds both ``'data'`` and ``'count'`` items.
     samples_per_frame : int, optional
-        Number of fold times to process in one go.  This can be used to
+        Number of sample times to process in one go.  This can be used to
         optimize the process, though in general the default of 1 should work.
     dtype : `~numpy.dtype`, optional
         Output dtype.  Generally, the default of the dtype of the underlying
@@ -41,7 +116,7 @@ class Fold(BaseTaskBase):
 
     Notes
     -----
-    Since the fold time is not necessarily an integer multiple of the pulse
+    Since the sample time is not necessarily an integer multiple of the pulse
     period, the returned profiles will generally not contain the same number
     of samples in each phase bin.  The actual number of samples is counted,
     and for ``average=True``, the sums have been divided by these counts, with

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -45,9 +45,6 @@ class IntegrateBase(BaseTaskBase):
     def __init__(self, ih, shape, sample_rate, average=True,
                  samples_per_frame=1, dtype=None):
         self.average = average
-        nframes = (shape[0] // samples_per_frame) * samples_per_frame
-        assert nframes > 0, "time per frame larger than total time in stream"
-        shape = (nframes,) + shape[1:]
         if dtype is None:
             if average:
                 dtype = ih.dtype

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -1,6 +1,8 @@
 # Licensed under the GPLv3 - see LICENSE
 """Tasks for integration over time and pulse phase."""
 
+import operator
+
 import numpy as np
 import astropy.units as u
 from astropy.utils import ShapedLikeNDArray
@@ -37,21 +39,30 @@ class _FakeOutput(ShapedLikeNDArray):
 class IntegrateBase(BaseTaskBase):
     """Base class for integrations over fixed sample times."""
 
-    def __init__(self, ih, sample_time=None, average=True,
+    def __init__(self, ih, n_sample=None, average=True,
                  samples_per_frame=1, sample_shape=None, dtype=None):
         self.ih = ih
         self.average = average
 
         total_time = ih.stop_time - ih.start_time
-        if sample_time is None:
-            sample_time = total_time
+        if n_sample is None:
+            n_sample = self.ih.shape[0]
 
-        nsample = int((total_time / sample_time).to_value(1) //
-                      samples_per_frame) * samples_per_frame
-        assert nsample > 0, "time per frame larger than total time in stream"
+        try:
+            n_sample = operator.index(n_sample)
+        except TypeError:
+            sample_rate = 1. / n_sample
+            nframes = int((total_time / n_sample).to_value(u.one))
+        else:
+            sample_rate = self.ih.sample_rate / n_sample
+            nframes = self.ih.shape[0] // n_sample
+
         if sample_shape is None:
             sample_shape = ih.sample_shape
-        shape = (nsample,) + sample_shape
+
+        nframes = (nframes // samples_per_frame) * samples_per_frame
+        assert nframes > 0, "time per frame larger than total time in stream"
+        shape = (nframes,) + sample_shape
 
         if dtype is None:
             if average:
@@ -59,15 +70,16 @@ class IntegrateBase(BaseTaskBase):
             else:
                 dtype = np.dtype([('data', ih.dtype), ('count', int)])
 
-        super().__init__(ih, shape=shape, sample_rate=1./sample_time,
+        super().__init__(ih, shape=shape, sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame, dtype=dtype)
-        self._raw_samples_per_frame = samples_per_frame * sample_time
+        self._n_sample = n_sample
+        self._raw_samples_per_frame = samples_per_frame * n_sample
 
     def _read_frame(self, frame_index):
         """Determine which raw samples to read, and read them using integrating read.
 
-        This base implementation uses the default ``_raw_samples_per_frame`` attribute,
-        which will generally have units of time.
+        This base implementation uses the default ``_raw_samples_per_frame`` attribute;
+        note that this can have units of time.
         """
         # Use seek to find the stop and start positions; this will round to the
         # nearest offset if necessary.
@@ -110,8 +122,9 @@ class Integrate(IntegrateBase):
     ----------
     ih : task or `baseband` stream reader
         Input data stream, with time as the first axis.
-    sample_time : `~astropy.units.Quantity`, optional
-        With units of time.  By default, will integrate the whole input stream.
+    n_sample : int or `~astropy.units.Quantity`, optional
+        Number of input samples or time interval over which to integrate.
+        If not given, the whole file will be integrated over.
     average : bool, optional
         Whether to calculate sums (with a ``count`` attribute) or to average
         values.
@@ -123,19 +136,21 @@ class Integrate(IntegrateBase):
 
     Notes
     -----
-    Since the sample time is not necessarily an integer multiple of the pulse
-    period, the returned profiles will generally not contain the same number
-    of samples in each phase bin.  The actual number of samples is counted,
-    and for ``average=True``, the sums have been divided by these counts, with
-    bins with no points set to ``NaN``.  For ``average=False``, the arrays
-    returned by ``read`` are structured arrays with ``data`` and ``count``
-    fields.
+
+    If ``n_sample`` is a time interval and not an integer multiple of the
+    sample time of the underlying file, the returned integrated samples may
+    not all contain the same number of samples.  The actual number of samples
+    is counted, and for ``average=True``, the sums have been divided by these
+    counts, with bins with no points set to ``NaN``.  For ``average=False``,
+    the arrays returned by ``read`` are structured arrays with ``data`` and
+    ``count`` fields.
 
     .. warning: The format for ``average=False`` may change in the future.
+
     """
 
-    def __init__(self, ih, sample_time=None, average=True, dtype=None):
-        super().__init__(ih, sample_time=sample_time, average=average, dtype=dtype)
+    def __init__(self, ih, n_sample=None, average=True, dtype=None):
+        super().__init__(ih, n_sample=n_sample, average=average, dtype=dtype)
 
     def _integrate(self, item, data):
         assert type(item) is slice
@@ -156,8 +171,8 @@ class Fold(IntegrateBase):
         Should return pulse phases for given input time(s), passed in as an
         '~astropy.time.Time' object.  The output should be an array of float;
         the phase can include the cycle count.
-    sample_time : `~astropy.units.Quantity`, optional
-        Time interval over which to fold, i.e., the sample time of the output.
+    n_sample : int or `~astropy.units.Quantity`, optional
+        Number of input samples or time interval over which to fold.
         If not given, the whole file will be folded into a single profile.
     average : bool, optional
         Whether the output pulse profile should be the average of all entries
@@ -184,12 +199,12 @@ class Fold(IntegrateBase):
 
     .. warning: The format for ``average=False`` may change in the future.
     """
-    def __init__(self, ih, n_phase, phase, sample_time=None, average=True,
+    def __init__(self, ih, n_phase, phase, n_sample=None, average=True,
                  samples_per_frame=1, dtype=None):
         self.n_phase = n_phase
         self.phase = phase
 
-        super().__init__(ih, sample_time=sample_time, average=average,
+        super().__init__(ih, n_sample=n_sample, average=average,
                          sample_shape=(n_phase,) + ih.sample_shape,
                          samples_per_frame=samples_per_frame, dtype=dtype)
 

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -78,16 +78,17 @@ class IntegrateBase(BaseTaskBase):
     def _read_frame(self, frame_index):
         """Determine which raw samples to read, and read them using integrating read.
 
-        This base implementation uses the default ``_raw_samples_per_frame`` attribute;
+        Uses the ``_n_sample`` attribute to seek in the underlying stream;
         note that this can have units of time.
         """
+        base_offset = frame_index * self.samples_per_frame
+        raw_offsets = [self.ih.seek((base_offset + i) * self._n_sample)
+                       for i in range(self.samples_per_frame + 1)]
         # Use seek to find the stop and start positions; this will round to the
         # nearest offset if necessary.
-        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
-        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
-        return self._integrating_read(raw_stop - raw_start)
+        return self._integrating_read(*raw_offsets)
 
-    def _integrating_read(self, n_raw):
+    def _integrating_read(self, *raw_offsets):
         """Set up fake output for a read from the underlying stream.
 
         Subclasses have to provide an ``_integrate method`` which will be
@@ -103,10 +104,12 @@ class IntegrateBase(BaseTaskBase):
             self._result = out['data']
             self._count = out['count']
 
+        self.ih.seek(raw_offsets[0])
+        self._offsets = [(off - raw_offsets[0]) for off in raw_offsets]
         # Set up fake output with a shape that tells read how many samples to read
         # (and a remaining part that should pass consistency checks), plus a
         # call-back for out[...]=....
-        integrating_out = _FakeOutput((n_raw,) + self.ih.sample_shape,
+        integrating_out = _FakeOutput((self._offsets[-1],) + self.ih.sample_shape,
                                       self._integrate)
         self.ih.read(out=integrating_out)
         if self.average:
@@ -149,13 +152,18 @@ class Integrate(IntegrateBase):
 
     """
 
-    def __init__(self, ih, n_sample=None, average=True, dtype=None):
-        super().__init__(ih, n_sample=n_sample, average=average, dtype=dtype)
+    def __init__(self, ih, n_sample=None, average=True, samples_per_frame=1,
+                 dtype=None):
+        super().__init__(ih, n_sample=n_sample, average=average,
+                         samples_per_frame=samples_per_frame, dtype=dtype)
 
     def _integrate(self, item, data):
         assert type(item) is slice
-        self._result[:] += data.sum(0, keepdims=True)
-        self._count[:] += len(data)
+        indices = [0] + [(i - item.start) for i in self._offsets
+                         if item.start < i < item.stop]
+        self._result[:] += np.add.reduceat(data, indices)
+        self._count[:] += (np.diff(indices + [item.stop])
+                           .reshape((-1,) + (1,) * (self._count.ndim - 1)))
 
 
 class Fold(IntegrateBase):
@@ -214,7 +222,7 @@ class Fold(IntegrateBase):
         raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
         raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
         self._raw_time = self.ih.time
-        return self._integrating_read(raw_stop - raw_start)
+        return self._integrating_read(raw_start, raw_stop)
 
     def _integrate(self, item, raw):
         assert type(item) is slice

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import astropy.units as u
+from astropy.utils import ShapedLikeNDArray
 
 from .base import BaseTaskBase
 
@@ -10,13 +11,27 @@ from .base import BaseTaskBase
 __all__ = ['Integrate', 'Fold']
 
 
-class _IntegratorCallBack:
+class _FakeOutput(ShapedLikeNDArray):
+    """Pretend output class that diverts setting.
+
+    It subclasses `~astropy.utils.ShapedLikeNDArray` to mimic all the
+    shape properties of `~numpy.ndarray` given a (fake) shape.
+    """
     def __init__(self, shape, setitem):
-        self.shape = shape
-        self.setitem = setitem
+            self._shape = shape
+            self._setitem = setitem
 
     def __setitem__(self, item, value):
-        return self.setitem(item, value)
+        # Call back on out[item] = value.
+        return self._setitem(item, value)
+
+    # The two required parts for ShapedLikeNDArray.
+    @property
+    def shape(self):
+        return self._shape
+
+    def _apply(self, *args, **kwargs):
+        raise NotImplementedError("No _apply possible for _FakeOutput")
 
 
 class IntegrateBase(BaseTaskBase):
@@ -46,6 +61,45 @@ class IntegrateBase(BaseTaskBase):
         super().__init__(ih, shape=shape, sample_rate=1./sample_time,
                          samples_per_frame=samples_per_frame, dtype=dtype)
         self._raw_samples_per_frame = samples_per_frame * sample_time
+
+    def _read_frame(self, frame_index):
+        """Determine which raw samples to read, and read them using integrating read.
+
+        This base implementation uses the default ``_raw_samples_per_frame`` attribute,
+        which will generally have units of time.
+        """
+        # Use seek to find the stop and start positions; this will round to the
+        # nearest offset if necessary.
+        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
+        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
+        return self._integrating_read(raw_stop - raw_start)
+
+    def _integrating_read(self, n_raw):
+        """Set up fake output for a read from the underlying stream.
+
+        Subclasses have to provide an ``_integrate method`` which will be
+        used to override ``__setitem__`` in the fake output.
+        """
+        out = np.zeros((self.samples_per_frame,) + self.sample_shape,
+                       dtype=self.dtype)
+        if self.average:
+            self._result = out
+            self._count = np.zeros(out.shape[:2] + (1,) * (out.ndim - 2),
+                                   dtype=int)
+        else:
+            self._result = out['data']
+            self._count = out['count']
+
+        # Set up fake output with a shape that tells read how many samples to read
+        # (and a remaining part that should pass consistency checks), plus a
+        # call-back for out[...]=....
+        integrating_out = _FakeOutput((n_raw,) + self.ih.sample_shape,
+                                      self._integrate)
+        self.ih.read(out=integrating_out)
+        if self.average:
+            out /= self._count
+
+        return out
 
 
 class Integrate(IntegrateBase):
@@ -82,29 +136,7 @@ class Integrate(IntegrateBase):
     def __init__(self, ih, sample_time=None, average=True, dtype=None):
         super().__init__(ih, sample_time=sample_time, average=average, dtype=dtype)
 
-    def _read_frame(self, frame_index):
-        # Determine which raw samples to read, and read them.
-        # Note: self._raw_samples_per_frame can have units of time.
-        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
-        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
-        n_raw = raw_stop - raw_start
-        out = np.zeros((self.samples_per_frame,) + self.sample_shape,
-                       dtype=self.dtype)
-        if self.average:
-            self._result = out
-            self._count = np.zeros(out.shape[:1] + (1,) * (out.ndim - 1),
-                                   dtype=int)
-        else:
-            self._result = out['data']
-            self._count = out['count']
-        fake_out = _IntegratorCallBack((n_raw,) + self.ih.sample_shape,
-                                       self._callback)
-        fake_out = self.ih.read(out=fake_out)
-        if self.average:
-            out /= self._count
-        return out
-
-    def _callback(self, item, data):
+    def _integrate(self, item, data):
         assert type(item) is slice
         self._result[:] += data.sum(0, keepdims=True)
         self._count[:] += len(data)
@@ -161,32 +193,14 @@ class Fold(IntegrateBase):
                          samples_per_frame=samples_per_frame, dtype=dtype)
 
     def _read_frame(self, frame_index):
-        # Determine which raw samples to read, and read them.
-        # Note: self._raw_samples_per_frame can have units of time.
+        # Override base implementation since we need to know the start time
+        # in the underlying frame in order to calculate phases in _integrate.
         raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
         raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
         self._raw_time = self.ih.time
-        n_raw = raw_stop - raw_start
-        # Set up output arrays.
-        out = np.zeros((self.samples_per_frame,) + self.sample_shape,
-                       dtype=self.dtype)
-        if self.average:
-            self._result = out
-            self._count = np.zeros(out.shape[:2] + (1,) * (out.ndim - 2),
-                                   dtype=int)
-        else:
-            self._result = out['data']
-            self._count = out['count']
+        return self._integrating_read(raw_stop - raw_start)
 
-        fake_out = _IntegratorCallBack((n_raw,) + self.ih.sample_shape,
-                                       self._callback)
-        fake_out = self.ih.read(out=fake_out)
-        if self.average:
-            out /= self._count
-
-        return out
-
-    def _callback(self, item, raw):
+    def _integrate(self, item, raw):
         assert type(item) is slice
         # Get sample and phase indices.
         time_offset = np.arange(item.start, item.stop) / self.ih.sample_rate

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -48,6 +48,7 @@ class IntegrateBase(BaseTaskBase):
 
         nsample = int((total_time / sample_time).to_value(1) //
                       samples_per_frame) * samples_per_frame
+        assert nsample > 0, "time per frame larger than total time in stream"
         if sample_shape is None:
             sample_shape = ih.sample_shape
         shape = (nsample,) + sample_shape

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -299,7 +299,7 @@ class IntegratePhase(Integrate):
         stop = phase(ih.stop_time)
 
         shape = (int((stop - start) / step),) + ih.sample_shape
-        super().__init__(ih, shape=shape, sample_rate=1. / step / u.cycle,
+        super().__init__(ih, shape=shape, sample_rate=1. / step,
                          average=average, samples_per_frame=samples_per_frame,
                          dtype=dtype)
         self._start_phase = start
@@ -416,7 +416,7 @@ class Fold(IntegrateBase):
 
         # TODO: allow having a phase reference.
         phases = self.phase(self._raw_time + raw_items / self.ih.sample_rate)
-        phase_index = ((phases.to_value(u.one) * self.n_phase)
+        phase_index = ((phases.to_value(u.cycle) * self.n_phase)
                        % self.n_phase).astype(int)
         # Do the actual folding, adding the data to the sums and counts.
         # TODO: np.add.at is not very efficient; replace?
@@ -465,7 +465,7 @@ class Stack(BaseTaskBase):
     def __init__(self, ih, n_phase, phase, average=True,
                  samples_per_frame=1, dtype=None):
         # Set up the integration in phase bins.
-        phased = IntegratePhase(ih, 1./n_phase, phase, average=average,
+        phased = IntegratePhase(ih, u.cycle/n_phase, phase, average=average,
                                 samples_per_frame=samples_per_frame*n_phase,
                                 dtype=dtype)
         # And ensure we reshape it to cycles.

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -36,11 +36,41 @@ class _FakeOutput(ShapedLikeNDArray):
         raise NotImplementedError("No _apply possible for _FakeOutput")
 
 
-class IntegrateBase(BaseTaskBase):
-    """Base class for integrations over fixed sample times."""
+class Integrate(BaseTaskBase):
+    """Integrate a stream over specific time steps.
 
-    def __init__(self, ih, n_sample=None, average=True,
-                 samples_per_frame=1, sample_shape=None, dtype=None):
+    Parameters
+    ----------
+    ih : task or `baseband` stream reader
+        Input data stream, with time as the first axis.
+    n_sample : int or `~astropy.units.Quantity`, optional
+        Number of input samples or time interval over which to integrate.
+        If not given, the whole file will be integrated over.
+    average : bool, optional
+        Whether to calculate sums (with a ``count`` attribute) or to average
+        values.
+    dtype : `~numpy.dtype`, optional
+        Output dtype.  Generally, the default of the dtype of the underlying
+        stream is good enough, but can be used to increase precision.  Note
+        that if ``average=True``, it is the user's responsibilty to pass in
+        a structured dtype.
+
+    Notes
+    -----
+
+    If ``n_sample`` is a time interval and not an integer multiple of the
+    sample time of the underlying file, the returned integrated samples may
+    not all contain the same number of samples.  The actual number of samples
+    is counted, and for ``average=True``, the sums have been divided by these
+    counts, with bins with no points set to ``NaN``.  For ``average=False``,
+    the arrays returned by ``read`` are structured arrays with ``data`` and
+    ``count`` fields.
+
+    .. warning: The format for ``average=False`` may change in the future.
+
+    """
+    def __init__(self, ih, n_sample=None, average=True, samples_per_frame=1,
+                 dtype=None):
         self.ih = ih
         self.average = average
 
@@ -57,12 +87,9 @@ class IntegrateBase(BaseTaskBase):
             sample_rate = self.ih.sample_rate / n_sample
             nframes = self.ih.shape[0] // n_sample
 
-        if sample_shape is None:
-            sample_shape = ih.sample_shape
-
         nframes = (nframes // samples_per_frame) * samples_per_frame
         assert nframes > 0, "time per frame larger than total time in stream"
-        shape = (nframes,) + sample_shape
+        shape = (nframes,) + ih.sample_shape
 
         if dtype is None:
             if average:
@@ -73,7 +100,6 @@ class IntegrateBase(BaseTaskBase):
         super().__init__(ih, shape=shape, sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame, dtype=dtype)
         self._n_sample = n_sample
-        self._raw_samples_per_frame = samples_per_frame * n_sample
 
     def _read_frame(self, frame_index):
         """Determine which raw samples to read, and read them using integrating read.
@@ -114,46 +140,6 @@ class IntegrateBase(BaseTaskBase):
 
         return out
 
-
-class Integrate(IntegrateBase):
-    """Integrate a stream over specific time steps.
-
-    Parameters
-    ----------
-    ih : task or `baseband` stream reader
-        Input data stream, with time as the first axis.
-    n_sample : int or `~astropy.units.Quantity`, optional
-        Number of input samples or time interval over which to integrate.
-        If not given, the whole file will be integrated over.
-    average : bool, optional
-        Whether to calculate sums (with a ``count`` attribute) or to average
-        values.
-    dtype : `~numpy.dtype`, optional
-        Output dtype.  Generally, the default of the dtype of the underlying
-        stream is good enough, but can be used to increase precision.  Note
-        that if ``average=True``, it is the user's responsibilty to pass in
-        a structured dtype.
-
-    Notes
-    -----
-
-    If ``n_sample`` is a time interval and not an integer multiple of the
-    sample time of the underlying file, the returned integrated samples may
-    not all contain the same number of samples.  The actual number of samples
-    is counted, and for ``average=True``, the sums have been divided by these
-    counts, with bins with no points set to ``NaN``.  For ``average=False``,
-    the arrays returned by ``read`` are structured arrays with ``data`` and
-    ``count`` fields.
-
-    .. warning: The format for ``average=False`` may change in the future.
-
-    """
-
-    def __init__(self, ih, n_sample=None, average=True, samples_per_frame=1,
-                 dtype=None):
-        super().__init__(ih, n_sample=n_sample, average=average,
-                         samples_per_frame=samples_per_frame, dtype=dtype)
-
     def _integrate(self, item, data):
         assert type(item) is slice
         # Have offsets for raw frames 0, f1, f2, ..., fn.  Need to select all
@@ -168,7 +154,7 @@ class Integrate(IntegrateBase):
                                     .reshape((-1,) + (1,) * (self._count.ndim - 1)))
 
 
-class Fold(IntegrateBase):
+class Fold(Integrate):
     """Fold pulse profiles in fixed time intervals.
 
     Parameters
@@ -213,14 +199,15 @@ class Fold(IntegrateBase):
                  samples_per_frame=1, dtype=None):
         self.n_phase = n_phase
         self.phase = phase
-
+        # First set up as for integration.
         super().__init__(ih, n_sample=n_sample, average=average,
-                         sample_shape=(n_phase,) + ih.sample_shape,
                          samples_per_frame=samples_per_frame, dtype=dtype)
+        # But then adjust the shape to take into account that we're folding.
+        self._shape = (self._shape[0], n_phase) + ih.sample_shape
 
     def _read_frame(self, frame_index):
-        # Override base implementation since we need to know the start time
-        # in the underlying frame in order to calculate phases in _integrate.
+        # Before calling the base implementation, get the start time in the
+        # underlying frame, which we need to calculate phases in _integrate.
         self.ih.seek(frame_index * self._n_sample * self.samples_per_frame)
         self._raw_time = self.ih.time
         return super()._read_frame(frame_index)

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -43,7 +43,7 @@ class Integrate(BaseTaskBase):
     ----------
     ih : task or `baseband` stream reader
         Input data stream, with time as the first axis.
-    n_sample : int or `~astropy.units.Quantity`, optional
+    step : int or `~astropy.units.Quantity`, optional
         Number of input samples or time interval over which to integrate.
         If not given, the whole file will be integrated over.
     average : bool, optional
@@ -58,7 +58,7 @@ class Integrate(BaseTaskBase):
     Notes
     -----
 
-    If ``n_sample`` is a time interval and not an integer multiple of the
+    If ``step`` is a time interval and not an integer multiple of the
     sample time of the underlying file, the returned integrated samples may
     not all contain the same number of samples.  The actual number of samples
     is counted, and for ``average=True``, the sums have been divided by these
@@ -69,23 +69,23 @@ class Integrate(BaseTaskBase):
     .. warning: The format for ``average=False`` may change in the future.
 
     """
-    def __init__(self, ih, n_sample=None, average=True, samples_per_frame=1,
+    def __init__(self, ih, step=None, average=True, samples_per_frame=1,
                  dtype=None):
         self.ih = ih
         self.average = average
 
         total_time = ih.stop_time - ih.start_time
-        if n_sample is None:
-            n_sample = self.ih.shape[0]
+        if step is None:
+            step = self.ih.shape[0]
 
         try:
-            n_sample = operator.index(n_sample)
+            step = operator.index(step)
         except TypeError:
-            sample_rate = 1. / n_sample
-            nframes = int((total_time / n_sample).to_value(u.one))
+            sample_rate = 1. / step
+            nframes = int((total_time / step).to_value(u.one))
         else:
-            sample_rate = self.ih.sample_rate / n_sample
-            nframes = self.ih.shape[0] // n_sample
+            sample_rate = self.ih.sample_rate / step
+            nframes = self.ih.shape[0] // step
 
         nframes = (nframes // samples_per_frame) * samples_per_frame
         assert nframes > 0, "time per frame larger than total time in stream"
@@ -99,12 +99,12 @@ class Integrate(BaseTaskBase):
 
         super().__init__(ih, shape=shape, sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame, dtype=dtype)
-        self._n_sample = n_sample
+        self._step = step
 
     def _read_frame(self, frame_index):
         """Determine which raw samples to read, and read them using integrating read.
 
-        Uses the ``_n_sample`` attribute to seek in the underlying stream;
+        Uses the ``_step`` attribute to seek in the underlying stream;
         note that this can have units of time.
 
         Subclasses have to provide an ``_integrate method`` which will be
@@ -113,7 +113,7 @@ class Integrate(BaseTaskBase):
         # Use seek to find the positions of all the output samples; this will
         # round to the nearest offset in the raw stream if necessary.
         base_offset = frame_index * self.samples_per_frame
-        offsets = np.array([self.ih.seek((base_offset + i) * self._n_sample)
+        offsets = np.array([self.ih.seek((base_offset + i) * self._step)
                             for i in range(self.samples_per_frame + 1)])
         self.ih.seek(offsets[0])
         offsets -= offsets[0]
@@ -167,7 +167,7 @@ class Fold(Integrate):
         Should return pulse phases for given input time(s), passed in as an
         '~astropy.time.Time' object.  The output should be an array of float;
         the phase can include the cycle count.
-    n_sample : int or `~astropy.units.Quantity`, optional
+    step : int or `~astropy.units.Quantity`, optional
         Number of input samples or time interval over which to fold.
         If not given, the whole file will be folded into a single profile.
     average : bool, optional
@@ -195,12 +195,12 @@ class Fold(Integrate):
 
     .. warning: The format for ``average=False`` may change in the future.
     """
-    def __init__(self, ih, n_phase, phase, n_sample=None, average=True,
+    def __init__(self, ih, n_phase, phase, step=None, average=True,
                  samples_per_frame=1, dtype=None):
         self.n_phase = n_phase
         self.phase = phase
         # First set up as for integration.
-        super().__init__(ih, n_sample=n_sample, average=average,
+        super().__init__(ih, step=step, average=average,
                          samples_per_frame=samples_per_frame, dtype=dtype)
         # But then adjust the shape to take into account that we're folding.
         self._shape = (self._shape[0], n_phase) + ih.sample_shape
@@ -208,7 +208,7 @@ class Fold(Integrate):
     def _read_frame(self, frame_index):
         # Before calling the base implementation, get the start time in the
         # underlying frame, which we need to calculate phases in _integrate.
-        self.ih.seek(frame_index * self._n_sample * self.samples_per_frame)
+        self.ih.seek(frame_index * self._step * self.samples_per_frame)
         self._raw_time = self.ih.time
         return super()._read_frame(frame_index)
 

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -82,13 +82,13 @@ class IntegrateBase(BaseTaskBase):
         note that this can have units of time.
         """
         base_offset = frame_index * self.samples_per_frame
-        raw_offsets = [self.ih.seek((base_offset + i) * self._n_sample)
-                       for i in range(self.samples_per_frame + 1)]
+        raw_offsets = np.array([self.ih.seek((base_offset + i) * self._n_sample)
+                                for i in range(self.samples_per_frame + 1)])
         # Use seek to find the stop and start positions; this will round to the
         # nearest offset if necessary.
-        return self._integrating_read(*raw_offsets)
+        return self._integrating_read(raw_offsets)
 
-    def _integrating_read(self, *raw_offsets):
+    def _integrating_read(self, raw_offsets):
         """Set up fake output for a read from the underlying stream.
 
         Subclasses have to provide an ``_integrate method`` which will be
@@ -105,7 +105,7 @@ class IntegrateBase(BaseTaskBase):
             self._count = out['count']
 
         self.ih.seek(raw_offsets[0])
-        self._offsets = [(off - raw_offsets[0]) for off in raw_offsets]
+        self._offsets = raw_offsets - raw_offsets[0]
         # Set up fake output with a shape that tells read how many samples to read
         # (and a remaining part that should pass consistency checks), plus a
         # call-back for out[...]=....
@@ -159,11 +159,16 @@ class Integrate(IntegrateBase):
 
     def _integrate(self, item, data):
         assert type(item) is slice
-        indices = [0] + [(i - item.start) for i in self._offsets
-                         if item.start < i < item.stop]
-        self._result[:] += np.add.reduceat(data, indices)
-        self._count[:] += (np.diff(indices + [item.stop])
-                           .reshape((-1,) + (1,) * (self._count.ndim - 1)))
+        # Have offsets for raw frames 0, f1, f2, ..., fn.  Need to select all
+        # that have any overlap with start, stop.
+        start = np.searchsorted(self._offsets[1:], item.start, side='left')
+        stop = np.searchsorted(self._offsets[:-1], item.stop, side='right')
+        indices = self._offsets[start:stop + 1] - item.start  # Don't do in-place!
+        indices[0] = 0
+        indices[-1] = item.stop - item.start
+        self._result[start:stop] += np.add.reduceat(data, indices[:-1])
+        self._count[start:stop] += (np.diff(indices)
+                                    .reshape((-1,) + (1,) * (self._count.ndim - 1)))
 
 
 class Fold(IntegrateBase):
@@ -222,7 +227,7 @@ class Fold(IntegrateBase):
         raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
         raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
         self._raw_time = self.ih.time
-        return self._integrating_read(raw_start, raw_stop)
+        return self._integrating_read(np.array([raw_start, raw_stop]))
 
     def _integrate(self, item, raw):
         assert type(item) is slice

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -80,20 +80,18 @@ class IntegrateBase(BaseTaskBase):
 
         Uses the ``_n_sample`` attribute to seek in the underlying stream;
         note that this can have units of time.
-        """
-        base_offset = frame_index * self.samples_per_frame
-        raw_offsets = np.array([self.ih.seek((base_offset + i) * self._n_sample)
-                                for i in range(self.samples_per_frame + 1)])
-        # Use seek to find the stop and start positions; this will round to the
-        # nearest offset if necessary.
-        return self._integrating_read(raw_offsets)
-
-    def _integrating_read(self, raw_offsets):
-        """Set up fake output for a read from the underlying stream.
 
         Subclasses have to provide an ``_integrate method`` which will be
-        used to override ``__setitem__`` in the fake output.
+        used to override ``__setitem__`` in the fake output that is constructed.
         """
+        # Use seek to find the positions of all the output samples; this will
+        # round to the nearest offset in the raw stream if necessary.
+        base_offset = frame_index * self.samples_per_frame
+        offsets = np.array([self.ih.seek((base_offset + i) * self._n_sample)
+                            for i in range(self.samples_per_frame + 1)])
+        self.ih.seek(offsets[0])
+        offsets -= offsets[0]
+        # Set up real output.
         out = np.zeros((self.samples_per_frame,) + self.sample_shape,
                        dtype=self.dtype)
         if self.average:
@@ -103,13 +101,12 @@ class IntegrateBase(BaseTaskBase):
         else:
             self._result = out['data']
             self._count = out['count']
+        self._offsets = offsets
 
-        self.ih.seek(raw_offsets[0])
-        self._offsets = raw_offsets - raw_offsets[0]
         # Set up fake output with a shape that tells read how many samples to read
         # (and a remaining part that should pass consistency checks), plus a
         # call-back for out[...]=....
-        integrating_out = _FakeOutput((self._offsets[-1],) + self.ih.sample_shape,
+        integrating_out = _FakeOutput((offsets[-1],) + self.ih.sample_shape,
                                       self._integrate)
         self.ih.read(out=integrating_out)
         if self.average:
@@ -224,24 +221,21 @@ class Fold(IntegrateBase):
     def _read_frame(self, frame_index):
         # Override base implementation since we need to know the start time
         # in the underlying frame in order to calculate phases in _integrate.
-        raw_stop = self.ih.seek((frame_index + 1) * self._raw_samples_per_frame)
-        raw_start = self.ih.seek(frame_index * self._raw_samples_per_frame)
+        self.ih.seek(frame_index * self._n_sample * self.samples_per_frame)
         self._raw_time = self.ih.time
-        return self._integrating_read(np.array([raw_start, raw_stop]))
+        return super()._read_frame(frame_index)
 
     def _integrate(self, item, raw):
         assert type(item) is slice
         # Get sample and phase indices.
-        time_offset = np.arange(item.start, item.stop) / self.ih.sample_rate
+        raw_items = np.arange(item.start, item.stop)
         if self.samples_per_frame == 1:
             sample_index = 0
         else:
-            # This is not quite correct: should take into account possible
-            # time offset between self and underlying stream.
-            sample_index = (time_offset *
-                            self.sample_rate).to_value(u.one).astype(int)
+            sample_index = np.searchsorted(self._offsets[1:], raw_items)
+
         # TODO: allow having a phase reference.
-        phases = self.phase(self._raw_time + time_offset)
+        phases = self.phase(self._raw_time + raw_items / self.ih.sample_rate)
         phase_index = ((phases.to_value(u.one) * self.n_phase)
                        % self.n_phase).astype(int)
         # Do the actual folding, adding the data to the sums and counts.

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -223,6 +223,8 @@ class Fold(IntegrateBase):
         if self.samples_per_frame == 1:
             sample_index = 0
         else:
+            # This is not quite correct: should take into account possible
+            # time offset between self and underlying stream.
             sample_index = (time_offset *
                             self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -220,8 +220,11 @@ class Fold(IntegrateBase):
         assert type(item) is slice
         # Get sample and phase indices.
         time_offset = np.arange(item.start, item.stop) / self.ih.sample_rate
-        sample_index = (time_offset *
-                        self.sample_rate).to_value(u.one).astype(int)
+        if self.samples_per_frame == 1:
+            sample_index = 0
+        else:
+            sample_index = (time_offset *
+                            self.sample_rate).to_value(u.one).astype(int)
         # TODO: allow having a phase reference.
         phases = self.phase(self._raw_time + time_offset)
         phase_index = ((phases.to_value(u.one) * self.n_phase)

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -8,8 +8,7 @@ from astropy.time import Time
 
 from ..base import Task
 from ..generators import EmptyStreamGenerator
-from ..integration import (Integrate, IntegrateSamples, IntegrateTime,
-                           Fold, Stack)
+from ..integration import Integrate, Fold, Stack
 from ..functions import Square
 
 
@@ -44,14 +43,12 @@ class TestFakePulsarBase:
 class TestIntegrate(TestFakePulsarBase):
     """Test integrating intensities using Baseband's sample DADA file."""
 
-    @pytest.mark.parametrize('integrate_cls', (Integrate, IntegrateSamples,
-                                               IntegrateTime))
-    def test_integrate_all(self, integrate_cls):
+    def test_integrate_all(self):
         # Load baseband file and get reference intensities.
         ref_data = self.raw_power.mean(0)
 
         st = Square(self.sh)
-        ip = integrate_cls(st)
+        ip = Integrate(st)
         assert ip.start_time == self.sh.start_time
         assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
         assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 
 from ..base import Task
 from ..generators import EmptyStreamGenerator
-from ..integration import Integrate, Fold
+from ..integration import Integrate, Fold, IntegrateByPhase
 from ..functions import Square
 
 
@@ -26,7 +26,7 @@ class TestFakePulsarBase:
         self.F0 = 1.0 / (self.period_bin / self.sh.sample_rate)
         self.n_phase = 50
         self.raw_data = self.sh.read()
-        self.raw_power = np.abs(self.raw_data)**2
+        self.raw_power = self.raw_data ** 2
         self.sh.seek(0)
 
     def phase(self, t):
@@ -238,3 +238,26 @@ class TestFold(TestFakePulsarBase):
             Fold(self.sh, 8, self.phase, step=1.*u.hr)
         with pytest.raises(AssertionError):
             Fold(self.sh, 8, self.phase, samples_per_frame=2)
+
+
+class TestIntegrateByPhase(TestFakePulsarBase):
+    def test_basic_stack(self):
+        ref_data = self.raw_data[:100].reshape(-1, 5, 2).mean(1)
+
+        fh = IntegrateByPhase(self.sh, 25, self.phase)
+        assert fh.start_time == self.sh.start_time
+        assert fh.stop_time == self.sh.stop_time
+
+        data = fh.read(20)
+        assert np.all(data == ref_data)
+
+    def test_full_stack(self):
+        ref_data = self.raw_data.reshape(-1, 5, 2).mean(1)
+
+        fh = IntegrateByPhase(self.sh, 25, self.phase,
+                              samples_per_frame=160)
+        assert fh.start_time == self.sh.start_time
+        assert fh.stop_time == self.sh.stop_time
+
+        data = fh.read()
+        assert np.all(data == ref_data)

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -6,29 +6,52 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time
 
-from baseband.data import SAMPLE_DADA
-from baseband import dada
-
 from ..base import Task
 from ..generators import EmptyStreamGenerator
 from ..integration import Integrate, Fold
 from ..functions import Square
 
 
-class TestIntegrate:
+class TestFakePulsarBase:
+    def setup(self):
+        self.start_time = Time('2010-11-12T13:14:15')
+        self.sample_rate = 10. * u.kHz
+        self.shape = (16000, 2)
+        self.eh = EmptyStreamGenerator(shape=self.shape,
+                                       start_time=self.start_time,
+                                       sample_rate=self.sample_rate,
+                                       samples_per_frame=200, dtype=np.float)
+        self.sh = Task(self.eh, self.pulse_simulate)
+        self.period_bin = 125
+        self.F0 = 1.0 / (self.period_bin / self.sh.sample_rate)
+        self.n_phase = 50
+        self.raw_data = self.sh.read()
+        self.raw_power = np.abs(self.raw_data)**2
+        self.sh.seek(0)
+
+    def phase(self, t):
+        return self.F0 * (t - self.start_time)
+
+    def pulse_simulate(self, fh, data):
+        idx = fh.tell() + np.arange(data.shape[0])
+        result = np.where(idx % self.period_bin == 0, 10., 0.125)
+        result.shape = (-1,) + (1,) * (data.ndim - 1)
+        data[:] = result
+        return data
+
+
+class TestIntegrate(TestFakePulsarBase):
     """Test integrating intensities using Baseband's sample DADA file."""
 
     def test_integrate_all(self):
         # Load baseband file and get reference intensities.
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read()
-        ref_data = np.real(raw * np.conj(raw)).mean(0)
+        ref_data = self.raw_power.mean(0)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st)
-        assert ip.start_time == fh.start_time
-        assert abs(ip.stop_time - fh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - fh.start_time - 1./ip.sample_rate) < 1. * u.ns
+        assert ip.start_time == self.sh.start_time
+        assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
+        assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         data = ip.read()
@@ -39,15 +62,13 @@ class TestIntegrate:
 
     def test_integrate_all_no_average(self):
         # Load baseband file and get reference intensities.
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read()
-        ref_data = np.real(raw * np.conj(raw)).sum(0)
+        ref_data = self.raw_power.sum(0)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st, average=False)
-        assert ip.start_time == fh.start_time
-        assert abs(ip.stop_time - fh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - fh.start_time - 1./ip.sample_rate) < 1. * u.ns
+        assert ip.start_time == self.sh.start_time
+        assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
+        assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         integrated = ip.read()
@@ -57,26 +78,24 @@ class TestIntegrate:
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == (1, 2)
         assert np.allclose(data, ref_data)
-        assert np.all(count == fh.shape[0])
+        assert np.all(count == self.sh.shape[0])
 
     @pytest.mark.parametrize('samples_per_frame', (1, 4, 10))
     @pytest.mark.parametrize('n', (1, 3))
     def test_integrate_n(self, n, samples_per_frame):
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(10 * n)
-        ref_data = np.real(raw * np.conj(raw)).reshape(-1, n, 2).sum(1)
+        ref_data = self.raw_power[121 * n:131 * n].reshape(-1, n, 2).sum(1)
 
-        st = Square(fh)
+        st = Square(self.sh)
         ip = Integrate(st, n, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n
 
-        # Square and integrate everything.
+        ip.seek(121)
         integrated = ip.read(10)
         data = integrated['data']
         count = integrated['count']
-        assert ip.tell() == 10
+        assert ip.tell() == 131
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == ref_data.shape
         assert np.allclose(data, ref_data)
@@ -85,21 +104,19 @@ class TestIntegrate:
     @pytest.mark.parametrize('samples_per_frame', (1, 4, 10))
     @pytest.mark.parametrize('n', (1, 3))
     def test_integrate_n_via_time(self, n, samples_per_frame):
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(10 * n)
-        ref_data = np.real(raw * np.conj(raw)).reshape(-1, n, 2).sum(1)
+        ref_data = self.raw_power[151*n:161*n].reshape(-1, n, 2).sum(1)
 
-        st = Square(fh)
-        ip = Integrate(st, n/fh.sample_rate, average=False,
+        st = Square(self.sh)
+        ip = Integrate(st, n/self.sh.sample_rate, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n
 
-        # Square and integrate everything.
+        ip.seek(151)
         integrated = ip.read(10)
         data = integrated['data']
         count = integrated['count']
-        assert ip.tell() == 10
+        assert ip.tell() == 161
         assert st.dtype is ref_data.dtype is data.dtype
         assert data.shape == ref_data.shape
         assert np.allclose(data, ref_data)
@@ -113,16 +130,14 @@ class TestIntegrate:
         # 3rd ..             4.52 - 6.78 -> 2 samples; etc.
         expected_count = [2, 3, 2, 2, 2, 3, 2, 2]
         n_sample = 2.26
-        fh = dada.open(SAMPLE_DADA)
-        raw = fh.read(18)
-        ref_data = np.add.reduceat(np.real(raw * np.conj(raw)),
-                                   np.add.accumulate([0] + expected_count[:-1]))
+        raw = self.raw_power[:18]
+        ref_data = np.add.reduceat(raw, np.add.accumulate([0] + expected_count[:-1]))
 
-        st = Square(fh)
-        ip = Integrate(st, n_sample / fh.sample_rate, average=False,
+        st = Square(self.sh)
+        ip = Integrate(st, n_sample / self.sh.sample_rate, average=False,
                        samples_per_frame=samples_per_frame)
-        assert ip.start_time == fh.start_time
-        assert ip.sample_rate == fh.sample_rate / n_sample
+        assert ip.start_time == self.sh.start_time
+        assert ip.sample_rate == self.sh.sample_rate / n_sample
 
         # Square and integrate everything.
         integrated = ip.read(8)
@@ -135,40 +150,14 @@ class TestIntegrate:
         assert np.all(count.T == expected_count)
 
     def test_time_too_large(self):
-        fh = dada.open(SAMPLE_DADA)
         with pytest.raises(AssertionError):
-            Integrate(fh, n_sample=1.*u.hr)
+            Integrate(self.sh, n_sample=1.*u.hr)
 
 
-class TestFoldBase:
-    def setup(self):
-        self.start_time = Time('2010-11-12T13:14:15')
-        self.sample_rate = 10. * u.kHz
-        self.shape = (6000, 2, 4)
-        self.eh = EmptyStreamGenerator(shape=self.shape,
-                                       start_time=self.start_time,
-                                       sample_rate=self.sample_rate,
-                                       samples_per_frame=200, dtype=np.float)
-        self.sh = Task(self.eh, self.pulse_simulate)
-        self.period_bin = 125
-        self.F0 = 1.0 / (self.period_bin / self.sh.sample_rate)
-        self.n_phase = 50
-
-    def phase(self, t):
-        return self.F0 * (t - self.start_time)
-
-    def pulse_simulate(self, fh, data):
-        idx = fh.tell() + np.arange(data.shape[0])
-        result = np.where(idx % self.period_bin == 0, 10., 0.125)
-        result.shape = (-1,) + (1,) * (data.ndim - 1)
-        data[:] = result
-        return data
-
-
-class TestFold(TestFoldBase):
+class TestFold(TestFakePulsarBase):
     def test_input_data(self):
-        indata = self.sh.read(1000)
-        pulses = np.where(indata[:, 0, 0] == 10)[0]
+        indata = self.raw_data[:1000]
+        pulses = np.where(indata[:, 0] == 10)[0]
         # Check if the input data is set up right.
         assert len(pulses) == 8, "Pulses are not simulated right."
 
@@ -207,7 +196,7 @@ class TestFold(TestFoldBase):
             "Folding counts vary more than expected."
         # Test the output on and off gates.
         ph0_bins = [0, 1, -1, -2]
-        pulse_power = np.sum(fr_data[:, ph0_bins, 0, 0], axis=1)
+        pulse_power = np.sum(fr_data[:, ph0_bins, 0], axis=1)
         assert 30 < pulse_power[0] < 33, \
             "Folded power of on-gate is incorrect."
 
@@ -231,7 +220,7 @@ class TestFold(TestFoldBase):
             "Average off-gate power is incorrect."
 
     def test_read_whole_file(self):
-        ref_data = self.sh.read()[:, 0, 0]
+        ref_data = self.raw_data[:, 0]
         phase = self.phase(self.start_time +
                            np.arange(self.sh.shape[0]) / self.sh.sample_rate)
         i_phase = ((phase * self.n_phase) % self.n_phase).astype(int)
@@ -242,7 +231,7 @@ class TestFold(TestFoldBase):
         fr = fh.read(1)
         assert np.all(fr[:, 2:-1] == 0.125), \
             "Average off-gate power is incorrect."
-        assert np.all(fr[0, :, 0, 0] == expected)
+        assert np.all(fr[0, :, 0] == expected)
 
     def test_time_too_large(self):
         with pytest.raises(AssertionError):

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 
 from ..base import Task
 from ..generators import EmptyStreamGenerator
-from ..integration import Integrate, Fold, IntegrateByPhase, Stack
+from ..integration import Integrate, Fold, IntegratePhase, Stack
 from ..functions import Square
 
 
@@ -240,14 +240,14 @@ class TestFold(TestFakePulsarBase):
             Fold(self.sh, 8, self.phase, samples_per_frame=2)
 
 
-class TestIntegrateByPhase(TestFakePulsarBase):
+class TestIntegratePhase(TestFakePulsarBase):
     # More detailed tests done in TestStack.
     @pytest.mark.parametrize('samples_per_frame', (1, 160))
     def test_basics(self, samples_per_frame):
         ref_data = self.raw_data.reshape(-1, 5, 2).mean(1)
 
-        fh = IntegrateByPhase(self.sh, 25, self.phase,
-                              samples_per_frame=samples_per_frame)
+        fh = IntegratePhase(self.sh, 25, self.phase,
+                            samples_per_frame=samples_per_frame)
         assert fh.start_time == self.sh.start_time
         assert fh.stop_time == self.sh.stop_time
         assert fh.sample_rate == 25 / u.cycle

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -9,7 +9,7 @@ from astropy.time import Time
 from ..base import Task
 from ..generators import EmptyStreamGenerator
 from ..integration import (Integrate, IntegrateSamples, IntegrateTime,
-                           IntegratePhase, Fold, Stack)
+                           Fold, Stack)
 from ..functions import Square
 
 
@@ -249,8 +249,8 @@ class TestIntegratePhase(TestFakePulsarBase):
     def test_basics(self, samples_per_frame):
         ref_data = self.raw_data.reshape(-1, 5, 2).mean(1)
 
-        fh = IntegratePhase(self.sh, u.cycle/25, self.phase,
-                            samples_per_frame=samples_per_frame)
+        fh = Integrate(self.sh, u.cycle/25, self.phase,
+                       samples_per_frame=samples_per_frame)
         assert fh.start_time == self.sh.start_time
         assert fh.stop_time == self.sh.stop_time
         assert fh.sample_rate == 25 / u.cycle

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -31,7 +31,7 @@ class TestFakePulsarBase:
         self.sh.seek(0)
 
     def phase(self, t):
-        return self.F0 * (t - self.start_time)
+        return u.cycle * self.F0 * (t - self.start_time)
 
     def pulse_simulate(self, fh, data):
         idx = fh.tell() + np.arange(data.shape[0])
@@ -226,7 +226,7 @@ class TestFold(TestFakePulsarBase):
         ref_data = self.raw_data[:, 0]
         phase = self.phase(self.start_time +
                            np.arange(self.sh.shape[0]) / self.sh.sample_rate)
-        i_phase = ((phase * self.n_phase) % self.n_phase).astype(int)
+        i_phase = ((phase.to_value(u.cycle) * self.n_phase) % self.n_phase).astype(int)
         expected = np.bincount(i_phase, ref_data) / np.bincount(i_phase)
 
         fh = Fold(self.sh, self.n_phase, self.phase, average=True)
@@ -249,7 +249,7 @@ class TestIntegratePhase(TestFakePulsarBase):
     def test_basics(self, samples_per_frame):
         ref_data = self.raw_data.reshape(-1, 5, 2).mean(1)
 
-        fh = IntegratePhase(self.sh, 1/25, self.phase,
+        fh = IntegratePhase(self.sh, u.cycle/25, self.phase,
                             samples_per_frame=samples_per_frame)
         assert fh.start_time == self.sh.start_time
         assert fh.stop_time == self.sh.stop_time

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -1,5 +1,5 @@
 # Licensed under the GPLv3 - see LICENSE
-"""Full-package tests of pulse folding."""
+"""Tests of integration and pulse folding."""
 
 import pytest
 import numpy as np
@@ -113,9 +113,9 @@ class TestFold(TestFoldBase):
         # Check if the input data is set up right.
         assert len(pulses) == 8, "Pulses are not simulated right."
 
-    def test_fold_time_shorter_than_period(self):
-        fold_time = 11 * u.ms
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time,
+    def test_sample_time_shorter_than_period(self):
+        sample_time = 11 * u.ms
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time,
                   samples_per_frame=1, average=False)
         fh.seek(0)
         fr = fh.read(3)
@@ -127,16 +127,16 @@ class TestFold(TestFoldBase):
 
         # For each of the samples, check that the correct ones have not
         # gotten any data.
-        eff_n_phase = (fold_time * self.F0 * self.n_phase).to_value(1)
+        eff_n_phase = (sample_time * self.F0 * self.n_phase).to_value(1)
         for ii, count in enumerate(fr_count):
             n_count_0 = (count == 0).sum()
             assert np.isclose(self.n_phase - n_count_0, eff_n_phase, 1), \
                 ("Sample {} has the wrong number of zero-count phase bins"
                  .format(ii))
 
-    def test_fold_time_longer_than_period(self):
-        fold_time = 26 * u.ms
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time,
+    def test_sample_time_longer_than_period(self):
+        sample_time = 26 * u.ms
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time,
                   samples_per_frame=1, average=False)
         fh.seek(0)
         fr = fh.read(10)
@@ -157,7 +157,7 @@ class TestFold(TestFoldBase):
 
     def test_folding_with_averaging(self):
         # Test averaging
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time=26 * u.ms,
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time=26 * u.ms,
                   samples_per_frame=20, average=True)
         fh.seek(0)
         fr = fh.read(10)
@@ -165,8 +165,8 @@ class TestFold(TestFoldBase):
             "Average off-gate power is incorrect."
 
     def test_non_integer_sample_rate_ratio(self):
-        fold_time = (1./3.) * u.s
-        fh = Fold(self.sh, self.n_phase, self.phase, fold_time, average=True)
+        sample_time = (1./3.) * u.s
+        fh = Fold(self.sh, self.n_phase, self.phase, sample_time, average=True)
         fr = fh.read(1)
         assert np.all(fr[:, 2:-1] == 0.125), \
             "Average off-gate power is incorrect."


### PR DESCRIPTION
This introduces integration by phase bins rather than by time; combined with a reshape that creates a pulse stack.

This builds on #50 which in turn builds on #47. Probably good to get some merged...  @luojing1211?

EDIT: I gave up on keeping #47 and #50 up to date as the classes ended up being taken apart and combined again (in quite a simple `Integrate` class), and I'm fairly sure this is the way to go.