### PR TITLE
StreamCombiner class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
                CONDA_DEPENDENCIES='scipy pyfftw'
 
         # Check oldest supported versions.
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13 ASTROPY_VERSION=3.1
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14 ASTROPY_VERSION=3.1
 
         # Make sure that egg_info works without dependencies
         - env: SETUP_CMD='egg_info'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ classes that can be linked together into a data reduction pipeline.
    :maxdepth: 1
 
    tasks/channelize
+   tasks/combining
    tasks/convolution
    tasks/dispersion
    tasks/functions

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Scintillometry requires:
 
     - `Python <https://www.python.org/>`_ v3.5 or later
     - `Astropy`_ v3.1 or later
-    - `Numpy <http://www.numpy.org/>`_ v1.13.0 or later
+    - `Numpy <http://www.numpy.org/>`_ v1.14 or later
     - `Baseband <https://pypi.org/project/baseband/>`_ v1.1 or later
 
 In addition, you may want to install:

--- a/docs/tasks/combining.rst
+++ b/docs/tasks/combining.rst
@@ -1,0 +1,18 @@
+.. _combining:
+
+**********************************************
+Combining streams (`scintillometry.combining`)
+**********************************************
+
+`~scintillometry.combining` contains tasks to combine multiple streams,
+e.g., in preparation for correlation.  The combining can be done
+using a user-defined function or with pre-defined implementations for
+concatenation and stacking.
+
+.. _combining_api:
+
+Reference/API
+=============
+
+.. automodapi:: scintillometry.combining
+   :no-inherited-members:

--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -78,6 +78,12 @@ class Base:
         Dtype of the samples.
     """
 
+    # Initial values for sample and frame pointers, etc.
+    offset = 0
+    _frame_index = None
+    _frame = None
+    closed = False
+
     def __init__(self, shape, start_time, sample_rate, samples_per_frame=1,
                  frequency=None, sideband=None, polarization=None,
                  dtype=np.complex64):
@@ -98,11 +104,6 @@ class Base:
         self._frequency = frequency
         self._sideband = sideband
         self._polarization = polarization
-
-        # Sample and frame pointers.
-        self.offset = 0
-        self._frame_index = None
-        self.closed = False
 
     def _check_shape(self, value):
         """Check that value can be broadcast to the sample shape."""

--- a/scintillometry/combining.py
+++ b/scintillometry/combining.py
@@ -1,0 +1,192 @@
+# Licensed under the GPLv3 - see LICENSE
+import numpy as np
+
+from .base import TaskBase, Task
+
+
+__all__ = ['CombineStreamsBase', 'CombineStreams', 'Concatenate', 'Stack']
+
+
+class CombineStreamsBase(TaskBase):
+    """Base class for combining streams.
+
+    Similar to `~scintillometry.base.TaskBase`, where a subclass can define
+    a ``task`` method to operate on data, but specifically for methods that
+    combine data from multiple streams that share a time axis.  This base
+    class ensures the operation is possible and that the ``frequency``,
+    ``sideband``, and ``polarization`` attributes are adjusted similarly.
+
+    Parameters
+    ----------
+    ihs : tuple of task or `baseband` stream readers
+        Input data streams.
+    """
+    def __init__(self, ihs):
+        try:
+            ih0 = ihs[0]
+        except (TypeError, IndexError) as exc:
+            exc.args += ("Need an iterable tuple containing "
+                         "at least one stream.",)
+            raise
+
+        # Check consistency of the streams.
+        self.ihs = ihs
+        for ih in ihs[1:]:
+            assert ih.sample_rate == ih0.sample_rate
+            assert ih.dtype == ih0.dtype
+            # TODO: lift this restriction?
+            assert ih.start_time == ih0.start_time
+            assert ih.shape[0] == ih0.shape[0]
+
+        # Check that the stream samples can be combined.
+        fakes = [np.empty((7,) + ih.sample_shape, ih.dtype) for ih in ihs]
+        try:
+            a = self.task(fakes)
+        except Exception as exc:
+            exc.args += ("stream samples with shapes {} cannot be combined "
+                         "as required".format([f.shape for f in fakes]),)
+            raise
+        if a.shape[0] != 7:
+            raise ValueError("stream combination affected the sample axis (0).")
+
+        # Calculate the combined shape and attributes.
+        shape = (ih0.shape[0],) + a.shape[1:]
+        attrs = {attr: self._combine_attr(attr)
+                 for attr in ('frequency', 'sideband', 'polarization')}
+        super().__init__(ih0, shape=shape, **attrs)
+
+    def _combine_attr(self, attr):
+        """Combine the given attribute from all streams.
+
+        Parameters
+        ----------
+        attr : str
+            Attribute to look up and combine
+
+        Returns
+        -------
+        combined : None or combined array
+             `None` if all attributes were `None`.
+        """
+        values = [getattr(ih, attr, None) for ih in self.ihs]
+
+        if all(value is None for value in values):
+            return None
+
+        # Don't count on our task to pass on subclasses
+        # (needs astropy >=4.0 and numpy >=1.17).
+        value0 = values[0]
+        unit = getattr(value0, 'unit', None)
+        if unit is not None:
+            values = [value.to_value(unit) for value in values]
+
+        values = [np.broadcast_to(value, (1,) + ih.sample_shape)
+                  for value, ih in zip(values, self.ihs)]
+
+        try:
+            result = self.task(values)
+        except Exception as exc:
+            exc.args += ("the {} attribute of the streams cannot be combined "
+                         "as required".format(attr),)
+            raise
+
+        if unit is None:
+            return result[0]
+        else:
+            return value0.__class__(result[0], unit, copy=False)
+
+    def close(self):
+        super().close()
+        for ih in self.ihs[1:]:
+            ih.close()
+
+    def _read_frame(self, frame_index):
+        """Read and combine data from the underlying filehandles."""
+        data = []
+        for ih in self.ihs:
+            ih.seek(frame_index * self._samples_per_frame)
+            data.append(ih.read(self._samples_per_frame))
+        return self.task(data)
+
+
+class CombineStreams(Task, CombineStreamsBase):
+    """Combining streams using a callable.
+
+    Parameters
+    ----------
+    ihs : tuple of task or `baseband` stream readers
+        Input data streams.
+    task : callable
+        The function or method-like callable. The task must work with
+        any number of data samples and combine the samples only.
+        It will also be applied to the ``frequency``, ``sideband``, and
+        ``polarization`` attributes of the underlying stream (if present).
+    method : bool, optional
+        Whether ``task`` is a method (two arguments) or a function
+        (one argument).  Default: inferred by inspection.
+
+    See Also
+    --------
+    Concatenate : to concatenate streams along an existing axis
+    Stack : to stack streams together along a new axis
+    """
+    def __init__(self, ihs, task, method=None):
+        super().__init__(ihs, task, method=method)
+
+
+class Concatenate(CombineStreamsBase):
+    """Concatenate streams along an existing axis.
+
+    Parameters
+    ----------
+    ihs : tuple of task or `baseband` stream readers
+        Input data streams.
+    axis : int
+        Axis along which to combine the samples. Should be a sample
+        axis and thus cannot be 0.
+
+    See Also
+    --------
+    Stack : to stack streams along a new axis
+    CombineStreams : to combine streams with a user-supplied function
+    """
+    def __init__(self, ihs, axis=1):
+        self.axis = axis
+        super().__init__(ihs)
+
+    def task(self, data):
+        # Reuse frame for in-place output if possible.
+        if getattr(self._frame, 'shape', [-1])[0] == data[0].shape[0]:
+            out = self._frame
+        else:
+            out = None
+        return np.concatenate(data, axis=self.axis, out=out)
+
+
+class Stack(CombineStreamsBase):
+    """Stack streams along a new axis.
+
+    Parameters
+    ----------
+    ihs : tuple of task or `baseband` stream readers
+        Input data streams.
+    axis : int
+        New axis along which to stack the samples. Should be a sample
+        axis and thus cannot be 0.
+
+    See Also
+    --------
+    Concatenate : to concatenate streams along an existing axis
+    CombineStreams : to combine streams with a user-supplied function
+    """
+    def __init__(self, ihs, axis=1):
+        self.axis = axis
+        super().__init__(ihs)
+
+    def task(self, data):
+        # Reuse frame for in-place output if possible.
+        if getattr(self._frame, 'shape', [-1])[0] == data[0].shape[0]:
+            out = self._frame
+        else:
+            out = None
+        return np.stack(data, axis=self.axis, out=out)

--- a/scintillometry/combining.py
+++ b/scintillometry/combining.py
@@ -25,8 +25,7 @@ class CombineStreamsBase(TaskBase):
         try:
             ih0 = ihs[0]
         except (TypeError, IndexError) as exc:
-            exc.args += ("Need an iterable tuple containing "
-                         "at least one stream.",)
+            exc.args += ("Need an iterable containing at least one stream.",)
             raise
 
         # Check consistency of the streams.
@@ -43,8 +42,8 @@ class CombineStreamsBase(TaskBase):
         try:
             a = self.task(fakes)
         except Exception as exc:
-            exc.args += ("stream samples with shapes {} cannot be combined "
-                         "as required".format([f.shape for f in fakes]),)
+            exc.args += ("streams with sample shapes {} cannot be combined "
+                         "as required".format([f.shape[1:] for f in fakes]),)
             raise
         if a.shape[0] != 7:
             raise ValueError("stream combination affected the sample axis (0).")
@@ -130,6 +129,8 @@ class CombineStreams(Task, CombineStreamsBase):
     Concatenate : to concatenate streams along an existing axis
     Stack : to stack streams together along a new axis
     """
+    # Override __init__ only to get rid of kwargs of Task, since these cannot
+    # be passed on to ChangeSampleShapeBase anyway.
     def __init__(self, ihs, task, method=None):
         super().__init__(ihs, task, method=method)
 

--- a/scintillometry/combining.py
+++ b/scintillometry/combining.py
@@ -155,6 +155,7 @@ class Concatenate(CombineStreamsBase):
         super().__init__(ihs)
 
     def task(self, data):
+        """Concatenate the pieces of data together."""
         # Reuse frame for in-place output if possible.
         if getattr(self._frame, 'shape', [-1])[0] == data[0].shape[0]:
             out = self._frame
@@ -184,6 +185,7 @@ class Stack(CombineStreamsBase):
         super().__init__(ihs)
 
     def task(self, data):
+        """Stack the pieces of data."""
         # Reuse frame for in-place output if possible.
         if getattr(self._frame, 'shape', [-1])[0] == data[0].shape[0]:
             out = self._frame

--- a/scintillometry/shaping.py
+++ b/scintillometry/shaping.py
@@ -336,4 +336,5 @@ class GetItem(ChangeSampleShapeBase):
         super().__init__(ih)
 
     def task(self, data):
+        """Get the preset item from the data."""
         return data[self._item]

--- a/scintillometry/shaping.py
+++ b/scintillometry/shaping.py
@@ -60,7 +60,7 @@ class ChangeSampleShape(Task, ChangeSampleShapeBase):
     ih : task or `baseband` stream reader
         Input data stream.
     task : callable
-        The function or method-like callable, The function must work with
+        The function or method-like callable. The task must work with
         any number of data samples and change the sample shape only.
         It will also be applied to the ``frequency``, ``sideband``, and
         ``polarization`` attributes of the underlying stream (if present).

--- a/scintillometry/tests/test_combining.py
+++ b/scintillometry/tests/test_combining.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_array_equal
 import astropy.units as u
 
 from baseband import vdif, dada
-from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
+from baseband.data import SAMPLE_VDIF
 
 from ..shaping import GetItem, Reshape
 from ..combining import Concatenate, Stack, CombineStreams

--- a/scintillometry/tests/test_combining.py
+++ b/scintillometry/tests/test_combining.py
@@ -1,0 +1,130 @@
+# Licensed under the GPLv3 - see LICENSE
+
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
+import astropy.units as u
+
+from baseband import vdif, dada
+from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
+
+from ..shaping import GetItem, Reshape
+from ..combining import Concatenate, Stack, CombineStreams
+
+from .test_shaping import get_fh
+
+
+class TestConcatenate:
+    @pytest.mark.parametrize('items',
+                             ((slice(None, 4), slice(4, None)),
+                              (slice(None, 3), slice(3, None)),
+                              (slice(None, 2), slice(2, 6), slice(6, None)),
+                              (slice(None),)))
+    def test_concatenate_simple(self, items):
+        fh = get_fh()
+        expected_data = fh.read()
+        fhs = [GetItem(fh, item) for item in items]
+        ch = Concatenate(fhs)
+        assert ch.shape == fh.shape
+        assert ch.start_time == fh.start_time
+        assert ch.sample_rate == fh.sample_rate
+        assert ch.dtype == fh.dtype
+        assert_array_equal(ch.frequency, fh.frequency)
+        assert_array_equal(ch.sideband, fh.sideband)
+        assert_array_equal(ch.polarization, fh.polarization)
+
+        data = ch.read()
+        assert_array_equal(data, expected_data)
+        ch.close()
+
+    def test_wrong_axis(self):
+        with get_fh() as fh:
+            with pytest.raises(ValueError):
+                Concatenate((fh, fh), axis=0)
+            with pytest.raises(ValueError):
+                Concatenate((fh, fh), axis=-2)
+
+
+class TestStack:
+    @pytest.mark.parametrize('axis', (1, 2, -1))
+    def test_stack_simple(self, axis):
+        fh = get_fh()
+        data = fh.read()
+        expected_data = np.stack((data[:, :4], data[:, 4:]), axis)
+        fh0 = GetItem(fh, slice(None, 4))
+        fh1 = GetItem(fh, slice(4, None))
+        ch = Stack((fh0, fh1), axis=axis)
+
+        assert ch.shape == expected_data.shape
+        assert ch.start_time == fh.start_time
+        assert ch.sample_rate == fh.sample_rate
+        assert ch.dtype == fh.dtype
+        assert_array_equal(ch.sideband, fh.sideband)
+        if axis == 1:
+            assert_array_equal(ch.frequency, fh.frequency.reshape(2, 4))
+            assert_array_equal(ch.polarization, fh.polarization[:4])
+        else:
+            assert_array_equal(ch.frequency, fh.frequency.reshape(2, 4).T)
+            assert_array_equal(ch.polarization,
+                               fh.polarization[:4].reshape(4, 1))
+
+        data = ch.read()
+        assert_array_equal(data, expected_data)
+        ch.close()
+
+    @pytest.mark.parametrize('axis', (1, 2, -1))
+    def test_stack_single_entry(self, axis):
+        fh = get_fh()
+        data = fh.read()
+        expected_data = np.stack((data,), axis=axis)
+        ch = Stack((fh,), axis=axis)
+
+        assert ch.shape == expected_data.shape
+        assert ch.start_time == fh.start_time
+        assert ch.sample_rate == fh.sample_rate
+        assert ch.dtype == fh.dtype
+        assert_array_equal(ch.sideband, fh.sideband)
+        if axis == 1:
+            assert_array_equal(ch.frequency, fh.frequency)
+            assert_array_equal(ch.polarization, fh.polarization)
+        else:
+            assert_array_equal(ch.frequency, fh.frequency[:, np.newaxis])
+            assert_array_equal(ch.polarization, fh.polarization[:, np.newaxis])
+
+        data = ch.read()
+        assert_array_equal(data, expected_data)
+        ch.close()
+
+    def test_wrong_axis(self):
+        with get_fh() as fh:
+            with pytest.raises(ValueError):
+                Stack((fh, fh), axis=0)
+            with pytest.raises(ValueError):
+                Stack((fh, fh), axis=-3)
+
+
+class TestCombineStreams:
+    def test_combine_callable(self):
+        def doublestack(data):
+            # concatenate frequencies, stack polarizations.
+            data = [np.stack(data[i:i+2], axis=1) for i in range(0, 8, 2)]
+            return np.stack(data, axis=1)
+
+        fh = get_fh()
+        fhs = [GetItem(fh, i) for i in range(8)]
+        ch = CombineStreams(fhs, doublestack)
+        expected = Reshape(fh, (4, 2))
+
+        assert ch.shape == expected.shape
+        assert ch.start_time == expected.start_time
+        assert ch.sample_rate == expected.sample_rate
+        assert ch.dtype == expected.dtype
+        assert_array_equal(ch.frequency, expected.frequency)
+        assert_array_equal(ch.sideband, expected.sideband)
+        assert_array_equal(ch.polarization, expected.polarization)
+
+        data = ch.read()
+        expected_data = expected.read()
+        assert_array_equal(data, expected_data)
+        ch.close()
+        expected.close()

--- a/scintillometry/tests/test_shaping.py
+++ b/scintillometry/tests/test_shaping.py
@@ -17,7 +17,7 @@ def get_fh():
     fh = vdif.open(SAMPLE_VDIF)
     # Add frequency, sideband, and polarization information by hand.
     fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 2) * 16. * u.MHz
-    fh.sideband = 1
+    fh.sideband = np.array(1)
     fh.polarization = np.tile(['L', 'R'], 4)
     return fh
 


### PR DESCRIPTION
fixes #99

At present, the code insists that the input streams have the same start times. This can be relaxed once we have the ability to extract time slices.