### PR TITLE
Delete rather than close ih

### DIFF
--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -409,7 +409,9 @@ class BaseTaskBase(Base):
     def close(self):
         """Close task, in particular closing its input source."""
         super().close()
-        self.ih.close()
+        # Delete the reference to the underlying filehandle, so that it
+        # can be freed if used nowhere else.
+        del self.ih
 
 
 class SetAttribute(BaseTaskBase):

--- a/scintillometry/shaping.py
+++ b/scintillometry/shaping.py
@@ -100,7 +100,7 @@ class ChangeSampleShape(Task, ChangeSampleShapeBase):
                    [343.25]] MHz>
         >>> sh.sideband
         array(1, dtype=int8)
-        >>> sh.close()
+        >>> fh.close()
     """
     # Override __init__ only to get rid of kwargs of Task, since these cannot
     # be passed on to ChangeSampleShapeBase anyway.
@@ -152,7 +152,7 @@ class Reshape(ChangeSampleShapeBase):
                    [359.25]] MHz>
         >>> rh.sideband
         array(1, dtype=int8)
-        >>> rh.close()
+        >>> fh.close()
     """
 
     def __init__(self, ih, sample_shape):
@@ -209,7 +209,7 @@ class Transpose(ChangeSampleShapeBase):
         <Quantity [311.25, 327.25, 343.25, 359.25] MHz>
         >>> th.sideband
         array(1, dtype=int8)
-        >>> th.close()
+        >>> fh.close()
 
     Note that the example above could also be done in one go using
     `~scintillometry.shaping.ReshapeAndTranspose`.
@@ -273,7 +273,7 @@ class ReshapeAndTranspose(Reshape):
         <Quantity [311.25, 327.25, 343.25, 359.25] MHz>
         >>> rth.sideband
         array(1, dtype=int8)
-        >>> rth.close()
+        >>> fh.close()
     """
 
     def __init__(self, ih, sample_shape, sample_axes):
@@ -326,7 +326,7 @@ class GetItem(ChangeSampleShapeBase):
         <Quantity [311.25, 311.25, 327.25, 327.25, 343.25, 343.25] MHz>
         >>> gih.sideband
         array(1, dtype=int8)
-        >>> gih.close()
+        >>> fh.close()
     """
     def __init__(self, ih, item):
         if isinstance(item, tuple):

--- a/scintillometry/tests/common.py
+++ b/scintillometry/tests/common.py
@@ -1,0 +1,39 @@
+# Licensed under the GPLv3 - see LICENSE
+"""Common parts to the tests."""
+import numpy as np
+from astropy import units as u
+
+from baseband import vdif, dada
+from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
+
+from ..base import SetAttribute
+
+
+class UseVDIFSample:
+    def setup(self):
+        self.fh = vdif.open(SAMPLE_VDIF)
+
+    def teardown(self):
+        self.fh.close()
+
+
+class UseDADASample:
+    def setup(self):
+        self.fh = dada.open(SAMPLE_DADA)
+
+    def teardown(self):
+        self.fh.close()
+
+
+class UseVDIFSampleWithAttrs:
+    def setup(self):
+        self._fh = vdif.open(SAMPLE_VDIF)
+        self.fh = SetAttribute(
+            self._fh,
+            frequency=311.25*u.MHz+(np.arange(8.)//2)*16.*u.MHz,
+            sideband=np.array(1),
+            polarization=np.tile(['L', 'R'], 4))
+
+    def teardown(self):
+        self.fh.close()
+        self._fh.close()

--- a/scintillometry/tests/test_convolution.py
+++ b/scintillometry/tests/test_convolution.py
@@ -9,34 +9,20 @@ from astropy.time import Time
 from ..convolution import Convolve, ConvolveSamples
 from ..generators import NoiseGenerator
 
-from baseband import vdif, dada
-from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
+from .common import UseDADASample
 
 
-class TestConvolve:
-    """Test convolution with simple smoothing filter."""
-
-    def setup(self):
-        self.response = np.ones(3)
-        self.start_time = Time('2010-11-12T13:14:15')
-        self.sample_rate = 10. * u.kHz
-        self.shape = (16000, 2)
-        self.nh = NoiseGenerator(shape=self.shape,
-                                 start_time=self.start_time,
-                                 sample_rate=self.sample_rate,
-                                 samples_per_frame=200, dtype=np.float,
-                                 seed=12345)
-        self.data = self.nh.read()
-
+class TestConvolveDADA(UseDADASample):
     @pytest.mark.parametrize('convolve_task', (ConvolveSamples, Convolve))
     def test_convolve(self, convolve_task):
         # Load baseband file and get reference intensities.
-        fh = dada.open(SAMPLE_DADA)
+        fh = self.fh
         ref_data = fh.read()
         expected = ref_data[:-2] + ref_data[1:-1] + ref_data[2:]
 
         # Have 16000 - 2 useful samples -> can use 842, but add 2 for response.
-        ct = convolve_task(fh, self.response, samples_per_frame=844)
+        response = np.ones(3)
+        ct = convolve_task(fh, response, samples_per_frame=844)
         # Convolve everything.
         data1 = ct.read()
         assert ct.tell() == ct.shape[0] == fh.shape[0] - 2
@@ -52,7 +38,21 @@ class TestConvolve:
         assert data2.shape[0] == 3
         assert np.allclose(expected[-3:], data2, atol=1.e-4)
 
-        ct.close()
+
+class TestConvolveNoise:
+    """Test convolution with simple smoothing filter."""
+
+    def setup(self):
+        self.response = np.ones(3)
+        self.start_time = Time('2010-11-12T13:14:15')
+        self.sample_rate = 10. * u.kHz
+        self.shape = (16000, 2)
+        self.nh = NoiseGenerator(shape=self.shape,
+                                 start_time=self.start_time,
+                                 sample_rate=self.sample_rate,
+                                 samples_per_frame=200, dtype=np.float,
+                                 seed=12345)
+        self.data = self.nh.read()
 
     @pytest.mark.parametrize('convolve_task', (ConvolveSamples, Convolve))
     @pytest.mark.parametrize('offset', (1, 2))

--- a/scintillometry/tests/test_shaping.py
+++ b/scintillometry/tests/test_shaping.py
@@ -9,25 +9,13 @@ from ..base import SetAttribute
 from ..shaping import (Reshape, Transpose, ReshapeAndTranspose,
                        ChangeSampleShape, GetItem)
 
-from baseband import vdif, dada
-from baseband.data import SAMPLE_VDIF, SAMPLE_DADA
+from .common import UseVDIFSampleWithAttrs
 
 
-def get_fh():
-    """Get sample VDIF file with correct frequency, sideband, polarization."""
-    fh = vdif.open(SAMPLE_VDIF)
-    # Add frequency, sideband, and polarization information by hand.
-    sa = SetAttribute(
-        fh, frequency=311.25*u.MHz+(np.arange(8.)//2)*16.*u.MHz,
-        sideband=np.array(1),
-        polarization=np.tile(['L', 'R'], 4))
-    return sa
-
-
-class TestReshape:
+class TestReshape(UseVDIFSampleWithAttrs):
     @pytest.mark.parametrize('sample_shape', ((4, 2), (2, 4)))
     def test_reshape(self, sample_shape):
-        fh = vdif.open(SAMPLE_VDIF)
+        fh = self.fh
         ref_data = fh.read().reshape((-1,) + sample_shape)
 
         rt = Reshape(fh, sample_shape=sample_shape)
@@ -38,42 +26,41 @@ class TestReshape:
 
         data = rt.read()
         assert_array_equal(data, ref_data)
-        rt.close()
 
     def test_frequency_sideband_polarization_propagation1(self):
-        fh = get_fh()
-        with Reshape(fh, (4, 2)) as rt:
-            assert rt.frequency.shape == (4, 1)
-            assert np.all(rt.frequency == fh.frequency[::2].reshape(4, 1))
-            assert rt.sideband.shape == ()
-            assert np.all(rt.sideband == 1)
-            assert rt.polarization.shape == (2,)
-            assert np.all(rt.polarization == fh.polarization[:2])
+        fh = self.fh
+        rt = Reshape(fh, (4, 2))
+        assert rt.frequency.shape == (4, 1)
+        assert np.all(rt.frequency == fh.frequency[::2].reshape(4, 1))
+        assert rt.sideband.shape == ()
+        assert np.all(rt.sideband == 1)
+        assert rt.polarization.shape == (2,)
+        assert np.all(rt.polarization == fh.polarization[:2])
 
     def test_frequency_sideband_polarization_propagation2(self):
-        fh = vdif.open(SAMPLE_VDIF)
         # Add different frequency, sideband, and polarization information.
         # (Note: these are incorrect; just for testing purposes.)
-        fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 4) * 16. * u.MHz
-        fh.sideband = np.tile([-1, 1], 4)
-        fh.polarization = np.tile(['L', 'L', 'R', 'R'], 2)
-        with Reshape(fh, (2, 2, 2)) as rt:
-            assert rt.frequency.shape == (2, 1, 1)
-            assert np.all(rt.frequency == fh.frequency[::4].reshape(2, 1, 1))
-            assert rt.sideband.shape == (2,)
-            assert np.all(rt.sideband == fh.sideband[:2])
-            assert rt.polarization.shape == (2, 1)
-            assert np.all(rt.polarization == fh.polarization[:4:2].reshape(2, 1))
+        fh = SetAttribute(
+            self.fh,
+            frequency=311.25 * u.MHz + (np.arange(8.) // 4) * 16. * u.MHz,
+            sideband=np.tile([-1, 1], 4),
+            polarization=np.tile(['L', 'L', 'R', 'R'], 2))
+        rt = Reshape(fh, (2, 2, 2))
+        assert rt.frequency.shape == (2, 1, 1)
+        assert np.all(rt.frequency == fh.frequency[::4].reshape(2, 1, 1))
+        assert rt.sideband.shape == (2,)
+        assert np.all(rt.sideband == fh.sideband[:2])
+        assert rt.polarization.shape == (2, 1)
+        assert np.all(rt.polarization == fh.polarization[:4:2].reshape(2, 1))
 
     def test_wrong_shape(self):
-        with vdif.open(SAMPLE_VDIF) as fh:
-            with pytest.raises(ValueError):
-                Reshape(fh, (4, 4))
-            with pytest.raises(ValueError):
-                Reshape(fh, ())
+        with pytest.raises(ValueError):
+            Reshape(self.fh, (4, 4))
+        with pytest.raises(ValueError):
+            Reshape(self.fh, ())
 
 
-class TestTranspose:
+class TestTranspose(UseVDIFSampleWithAttrs):
     """Test transpose on a reshaped stream."""
     @staticmethod
     def get_reshape_and_transpose(fh, sample_shape=(4, 2),
@@ -82,48 +69,46 @@ class TestTranspose:
         return Transpose(rt, sample_axes=sample_axes)
 
     def test_basic(self):
-        fh = vdif.open(SAMPLE_VDIF)
+        fh = self.fh
         ref_data = fh.read().reshape((-1, 4, 2)).transpose(0, 2, 1)
         tt = self.get_reshape_and_transpose(fh, (4, 2), (2, 1))
         assert tt.start_time == fh.start_time
         assert tt.sample_rate == fh.sample_rate
         data = tt.read()
         assert_array_equal(data, ref_data)
-        tt.close()
 
     def test_frequency_sideband_polarization_propagation1(self):
-        fh = get_fh()
-        with self.get_reshape_and_transpose(fh, (4, 2), (2, 1)) as tt:
-            assert tt.frequency.shape == (4,)
-            assert np.all(tt.frequency == fh.frequency[::2])
-            assert tt.sideband.shape == ()
-            assert np.all(tt.sideband == 1)
-            assert tt.polarization.shape == (2, 1)
-            assert np.all(tt.polarization == fh.polarization[:2].reshape(2, 1))
+        tt = self.get_reshape_and_transpose(self.fh, (4, 2), (2, 1))
+        assert tt.frequency.shape == (4,)
+        assert np.all(tt.frequency == self.fh.frequency[::2])
+        assert tt.sideband.shape == ()
+        assert np.all(tt.sideband == 1)
+        assert tt.polarization.shape == (2, 1)
+        assert np.all(tt.polarization == self.fh.polarization[:2].reshape(2, 1))
 
     def test_frequency_sideband_polarization_propagation2(self):
-        fh = vdif.open(SAMPLE_VDIF)
         # Add different frequency, sideband, and polarization information.
         # (Note: these are incorrect; just for testing purposes.)
-        fh.frequency = 311.25 * u.MHz + (np.arange(8.) // 4) * 16. * u.MHz
-        fh.sideband = np.tile([-1, 1], 4)
-        fh.polarization = np.tile(['L', 'L', 'R', 'R'], 2)
-        with self.get_reshape_and_transpose(fh, (2, 2, 2), (-1, -3, -2)) as tt:
-            assert tt.frequency.shape == (2, 1)
-            assert np.all(tt.frequency == fh.frequency[::4].reshape(2, 1))
-            assert tt.sideband.shape == (2, 1, 1)
-            assert np.all(tt.sideband == fh.sideband[:2].reshape(2, 1, 1))
-            assert tt.polarization.shape == (2,)
-            assert np.all(tt.polarization == fh.polarization[:4:2])
+        fh = SetAttribute(
+            self.fh,
+            frequency=311.25 * u.MHz + (np.arange(8.) // 4) * 16. * u.MHz,
+            sideband=np.tile([-1, 1], 4),
+            polarization=np.tile(['L', 'L', 'R', 'R'], 2))
+        tt = self.get_reshape_and_transpose(fh, (2, 2, 2), (-1, -3, -2))
+        assert tt.frequency.shape == (2, 1)
+        assert np.all(tt.frequency == fh.frequency[::4].reshape(2, 1))
+        assert tt.sideband.shape == (2, 1, 1)
+        assert np.all(tt.sideband == fh.sideband[:2].reshape(2, 1, 1))
+        assert tt.polarization.shape == (2,)
+        assert np.all(tt.polarization == fh.polarization[:4:2])
 
     def test_wrong_axes(self):
-        with vdif.open(SAMPLE_VDIF) as fh:
-            with pytest.raises(ValueError):
-                self.get_reshape_and_transpose(fh, (4, 2), (1, 0))
-            with pytest.raises(ValueError):
-                self.get_reshape_and_transpose(fh, (4, 2), (2, 3))
-            with pytest.raises(ValueError):
-                self.get_reshape_and_transpose(fh, (4, 2), (1, 1))
+        with pytest.raises(ValueError):
+            self.get_reshape_and_transpose(self.fh, (4, 2), (1, 0))
+        with pytest.raises(ValueError):
+            self.get_reshape_and_transpose(self.fh, (4, 2), (2, 3))
+        with pytest.raises(ValueError):
+            self.get_reshape_and_transpose(self.fh, (4, 2), (1, 1))
 
 
 class TestReshapeAndTranspose(TestTranspose):
@@ -151,7 +136,7 @@ class TestChangeSampleShape(TestTranspose):
         return ChangeSampleShape(fh, task)
 
     def test_swap_axes(self):
-        fh = get_fh()
+        fh = self.fh
         st = ChangeSampleShape(
             fh, lambda data: data.reshape(-1, 4, 2).swapaxes(1, 2))
         assert st.frequency.shape == (4,)
@@ -160,29 +145,28 @@ class TestChangeSampleShape(TestTranspose):
         assert np.all(st.sideband == 1)
         assert st.polarization.shape == (2, 1)
         assert np.all(st.polarization == fh.polarization[:2].reshape(2, 1))
-        st.close()
 
     def test_get_item(self):
         """Selecting from both axes of two-dimensional samples."""
-        fh = get_fh()
-        with ChangeSampleShape(
-                fh, lambda data: data.reshape(-1, 4, 2)[:, :2, 0]) as st:
-            assert st.frequency.shape == (2,)
-            assert_array_equal(st.frequency, fh.frequency[:4:2])
-            assert st.polarization.shape == ()
-            assert_array_equal(st.polarization, fh.polarization[0])
+        fh = self.fh
+        st = ChangeSampleShape(
+            fh, lambda data: data.reshape(-1, 4, 2)[:, :2, 0])
+        assert st.frequency.shape == (2,)
+        assert_array_equal(st.frequency, fh.frequency[:4:2])
+        assert st.polarization.shape == ()
+        assert_array_equal(st.polarization, fh.polarization[0])
 
     def test_no_extra_arguments(self):
         with pytest.raises(TypeError):
             ChangeSampleShape(None, None, shape=())
 
 
-class TestGetItem:
+class TestGetItem(UseVDIFSampleWithAttrs):
 
     @pytest.mark.parametrize('item', (0, slice(0, None, 2), [0, 1]))
     def test_basic(self, item):
         """Basic tests on one-dimensional samples."""
-        fh = get_fh()
+        fh = self.fh
         ref_data = fh.read()[:, item]
         gih = GetItem(fh, item)
         data = gih.read()
@@ -202,34 +186,33 @@ class TestGetItem:
 
     def test_specific1(self):
         """Selecting one item in first axis of two-dimensional samples."""
-        rh = Reshape(get_fh(), (4, 2))  # freq, pol
-        with GetItem(rh, 0) as gih:
-            assert gih.frequency.shape == ()
-            assert_array_equal(gih.frequency, rh.frequency[0, 0])
-            assert gih.polarization.shape == (2,)
-            assert_array_equal(gih.polarization, rh.polarization)
+        rh = Reshape(self.fh, (4, 2))  # freq, pol
+        gih = GetItem(rh, 0)
+        assert gih.frequency.shape == ()
+        assert_array_equal(gih.frequency, rh.frequency[0, 0])
+        assert gih.polarization.shape == (2,)
+        assert_array_equal(gih.polarization, rh.polarization)
 
     def test_specific2(self):
         """Selecting one item in second axis of two-dimensional samples."""
-        rh = Reshape(get_fh(), (4, 2))  # freq, pol
-        with GetItem(rh, (slice(None), 1)) as gih:
-            assert gih.frequency.shape == (4,)
-            assert_array_equal(gih.frequency, rh.frequency.squeeze())
-            assert gih.polarization.shape == ()
-            assert_array_equal(gih.polarization, rh.polarization[1])
+        rh = Reshape(self.fh, (4, 2))  # freq, pol
+        gih = GetItem(rh, (slice(None), 1))
+        assert gih.frequency.shape == (4,)
+        assert_array_equal(gih.frequency, rh.frequency.squeeze())
+        assert gih.polarization.shape == ()
+        assert_array_equal(gih.polarization, rh.polarization[1])
 
     def test_specific3(self):
         """Selecting from both axes of two-dimensional samples."""
-        rh = Reshape(get_fh(), (4, 2))  # freq, pol
-        with GetItem(rh, (slice(None, 2), 0)) as gih:
-            assert gih.frequency.shape == (2,)
-            assert_array_equal(gih.frequency, rh.frequency[:2].squeeze())
-            assert gih.polarization.shape == ()
-            assert_array_equal(gih.polarization, rh.polarization[0])
+        rh = Reshape(self.fh, (4, 2))  # freq, pol
+        gih = GetItem(rh, (slice(None, 2), 0))
+        assert gih.frequency.shape == (2,)
+        assert_array_equal(gih.frequency, rh.frequency[:2].squeeze())
+        assert gih.polarization.shape == ()
+        assert_array_equal(gih.polarization, rh.polarization[0])
 
     def test_wrong_item(self):
-        with vdif.open(SAMPLE_VDIF) as fh:
-            with pytest.raises(IndexError):
-                GetItem(fh, 10)
-            with pytest.raises(IndexError):
-                GetItem(fh, (1, 1))
+        with pytest.raises(IndexError):
+            GetItem(self.fh, 10)
+        with pytest.raises(IndexError):
+            GetItem(self.fh, (1, 1))


### PR DESCRIPTION
fixes #101 

I realized it was really not logical to delete all underlying filehandles. One should just delete the reference, and if it is the last one held, the file will be deleted and thus closed.

This way, one can use the sample input in multiple pipelines without worrying about the file closing under one's feet.

Note this affects very little actual code, but the tests had to be adapted to always close any data files one opens.