### PR TITLE
Avoid using python or numpy round

### DIFF
--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -196,8 +196,8 @@ class Integrate(BaseTaskBase):
         Phase is assumed to increase monotonously with time.
         """
         if self._phase is None:
-            return (np.round(samples / self._mean_offset_size +
-                             self._ih_start).astype(int))
+            return (np.around(samples / self._mean_offset_size +
+                              self._ih_start).astype(int))
 
         # Requested phases relative to start (we work relative to the start
         # to avoid rounding errors for large cycle counts).  Also, we want

--- a/scintillometry/phases/phase.py
+++ b/scintillometry/phases/phase.py
@@ -72,11 +72,11 @@ def day_frac(val1, val2, factor=None, divisor=None):
         sum12, err12 = two_sum(q1, q2)
 
     # get integer fraction
-    day = np.round(sum12)
+    day = np.around(sum12)
     extra, frac = two_sum(sum12, -day)
     frac += extra + err12
     # This part was missed in astropy...
-    excess = np.round(frac)
+    excess = np.around(frac)
     day += excess
     extra, frac = two_sum(sum12, -day)
     frac += extra + err12

--- a/scintillometry/sampling.py
+++ b/scintillometry/sampling.py
@@ -104,7 +104,7 @@ class Resample(PaddedTaskBase):
                  samples_per_frame=None):
 
         ih_offset = float_offset(ih, offset, whence)
-        rounded_offset = round(ih_offset)
+        rounded_offset = np.around(ih_offset)
         fraction = ih_offset - rounded_offset
         if fraction < 0:
             pad_start, pad_end = 1, 0
@@ -126,7 +126,7 @@ class Resample(PaddedTaskBase):
         self._start_time += fraction / ih.sample_rate
         self._pad_slice = slice(self._pad_start,
                                 self._padded_samples_per_frame - self._pad_end)
-        self.seek(rounded_offset - self._pad_start)
+        self.seek(int(rounded_offset) - self._pad_start)
 
     @lazyproperty
     def phase_factor(self):

--- a/scintillometry/tests/test_dispersion.py
+++ b/scintillometry/tests/test_dispersion.py
@@ -161,8 +161,8 @@ class TestDispersion:
         phases *= self.gp.sideband
         ft *= np.exp(-1j * phases.to_value(u.rad))
         gp_exp = ifft(ft)
-        offset = self.gp_sample + int(np.round(
-            (time_delay * self.sample_rate).to_value(u.one)))
+        offset = self.gp_sample + int(
+            (time_delay * self.sample_rate).to(u.one).round())
         assert np.all(np.abs(gp_exp[offset-1024:offset+1024] - dd_gp) < 1e-3)
 
     def test_disperse_negative_dm(self):


### PR DESCRIPTION
python round gives float on numpy floats (which may become an issue with astropy 4.0, which changes `.value` to give a numpy float), numpy round is just a needless wrapper for around.