### PR TITLE
Pep8 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,11 @@ env:
         # - SETUP_XVFB=True
 
         # If you want to ignore certain flake8 errors, you can list them
-        # in FLAKE8_OPT, for example:
-        # - FLAKE8_OPT='--ignore=E501'
-        - FLAKE8_OPT=''
+        # in FLAKE8_OPT, for example
+        # E226: missing whitespace around arithmetic operator
+        # E501: line too long
+        # W504: line break after binary operator
+        - FLAKE8_OPT='--ignore=E226,E501,W504'
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,9 @@ env:
         # If you want to ignore certain flake8 errors, you can list them
         # in FLAKE8_OPT, for example
         # E226: missing whitespace around arithmetic operator
-        # E501: line too long
-        # W504: line break after binary operator
-        - FLAKE8_OPT='--ignore=E226,E501,W504'
+        # W504: line break before binary operator
+        # By default, we just ignore whatever is in setup.cfg.
+        - FLAKE8_OPT=''
 
 
 matrix:

--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -456,6 +456,7 @@ class SetAttribute(BaseTaskBase):
         ``['X', 'Y']``, or ``[['L'], ['R']]``.
 
     """
+
     def __init__(self, ih, *, start_time=None, sample_rate=None,
                  frequency=None, sideband=None, polarization=None):
         super().__init__(ih, start_time=start_time, sample_rate=sample_rate,
@@ -524,14 +525,14 @@ class TaskBase(BaseTaskBase):
         else:
             sample_rate_ratio = (ih.sample_rate / sample_rate).to(1).value
         if samples_per_frame is None:
-            (samples_per_frame, r) = divmod(ih.samples_per_frame /
-                                            sample_rate_ratio, 1.)
+            (samples_per_frame, r) = divmod(ih.samples_per_frame
+                                            / sample_rate_ratio, 1.)
             assert r == 0, "inferred samples per frame must be integer"
             samples_per_frame = int(samples_per_frame)
             self._raw_samples_per_frame = ih.samples_per_frame
         else:
-            (raw_samples_per_frame, r) = divmod(samples_per_frame *
-                                                sample_rate_ratio, 1.)
+            (raw_samples_per_frame, r) = divmod(samples_per_frame
+                                                * sample_rate_ratio, 1.)
             assert r == 0, "inferred raw samples per frame must be integer"
             self._raw_samples_per_frame = int(raw_samples_per_frame)
 
@@ -618,6 +619,7 @@ class Task(TaskBase):
     AssertionError
         If the task has zero or more than 2 arguments.
     """
+
     def __init__(self, ih, task, method=None, **kwargs):
         if method is None:
             try:
@@ -668,6 +670,7 @@ class PaddedTaskBase(BaseTaskBase):
         Possible further arguments; see `~scintillometry.base.BaseTaskBase`.
 
     """
+
     def __init__(self, ih, pad_start=0, pad_end=0, *,
                  samples_per_frame=None, **kwargs):
         self._pad_start = operator.index(pad_start)

--- a/scintillometry/base.py
+++ b/scintillometry/base.py
@@ -6,7 +6,7 @@ import types
 import warnings
 
 import numpy as np
-import astropy.units as u
+from astropy import units as u
 
 
 __all__ = ['Base', 'BaseTaskBase', 'SetAttribute', 'TaskBase',
@@ -290,7 +290,7 @@ class Base:
             out = np.empty((count,) + self.shape[1:], dtype=self.dtype)
         else:
             assert out.shape[1:] == self.shape[1:], (
-                "'out' should have trailing shape {}".format(self.sample_shape))
+                "'out' must have trailing shape {}".format(self.sample_shape))
             count = out.shape[0]
 
         # TODO: should this just return the maximum possible?
@@ -560,8 +560,8 @@ class TaskBase(BaseTaskBase):
 class Task(TaskBase):
     """Apply a user-supplied callable to a stream.
 
-    The task can either behave like a function or a method.  If a function,
-    it will be passed just the frame data read from the underlying file or task;
+    The task can either behave like a function or a method.  If a function, it
+    will be passed just the frame data read from the underlying file or task;
     if a method, it will be passed the Task instance (with its offset at the
     correct sample) as well as the frame data read.
 

--- a/scintillometry/channelize.py
+++ b/scintillometry/channelize.py
@@ -2,8 +2,6 @@
 
 import operator
 
-import numpy as np
-
 from .base import TaskBase
 from .fourier import fft_maker
 
@@ -135,7 +133,7 @@ class Dechannelize(TaskBase):
             if dtype.kind == 'c':
                 n = ih.sample_shape[0]
             else:
-                raise ValueError("Need to pass in explicit n for real transform.")
+                raise ValueError("need explicit 'n' for real transform.")
         else:
             n = operator.index(n)
 

--- a/scintillometry/channelize.py
+++ b/scintillometry/channelize.py
@@ -66,8 +66,8 @@ class Channelize(TaskBase):
 
         if self._frequency is not None:
             # Do not use in-place, since _frequency is likely broadcast.
-            self._frequency = (self._frequency +
-                               self._fft.frequency * self.sideband)
+            self._frequency = (self._frequency
+                               + self._fft.frequency * self.sideband)
 
     def task(self, data):
         return self._fft(data.reshape(self._fft.time_shape))

--- a/scintillometry/combining.py
+++ b/scintillometry/combining.py
@@ -70,7 +70,7 @@ class CombineStreamsBase(TaskBase):
                          "as required".format([f.shape[1:] for f in fakes]),)
             raise
         if a.shape[0] != 7:
-            raise ValueError("stream combination affected the sample axis (0).")
+            raise ValueError("combination affected the sample axis (0).")
 
         # Calculate the combined shape and attributes.
         shape = (n_sample,) + a.shape[1:]

--- a/scintillometry/combining.py
+++ b/scintillometry/combining.py
@@ -30,6 +30,7 @@ class CombineStreamsBase(TaskBase):
         Useful mostly in case the stream readers have time offsets, since
         the output stream will be shortened by an integer number of frames.
     """
+
     def __init__(self, ihs, atol=None, samples_per_frame=None):
         try:
             ih0 = ihs[0]
@@ -168,6 +169,7 @@ class CombineStreams(Task, CombineStreamsBase):
     """
     # Override __init__ only to get rid of kwargs of Task, since these cannot
     # be passed on to ChangeSampleShapeBase anyway.
+
     def __init__(self, ihs, task, method=None, atol=None,
                  samples_per_frame=None):
         super().__init__(ihs, task, method=method, atol=atol,
@@ -198,6 +200,7 @@ class Concatenate(CombineStreamsBase):
     Stack : to stack streams along a new axis
     CombineStreams : to combine streams with a user-supplied function
     """
+
     def __init__(self, ihs, axis=1, atol=None, samples_per_frame=None):
         self.axis = axis
         super().__init__(ihs, atol=atol, samples_per_frame=samples_per_frame)
@@ -236,6 +239,7 @@ class Stack(CombineStreamsBase):
     Concatenate : to concatenate streams along an existing axis
     CombineStreams : to combine streams with a user-supplied function
     """
+
     def __init__(self, ihs, axis=1, atol=None, samples_per_frame=None):
         self.axis = axis
         super().__init__(ihs, atol=atol, samples_per_frame=samples_per_frame)

--- a/scintillometry/conversion.py
+++ b/scintillometry/conversion.py
@@ -65,8 +65,8 @@ class Real2Complex(TaskBase):
                          dtype=dtype)
 
         if self._frequency is not None:
-            self._frequency = (self._frequency +
-                               ih.sample_rate / 2 * self.sideband)
+            self._frequency = (self._frequency
+                               + ih.sample_rate / 2 * self.sideband)
 
     def task(self, data):
         z = data.astype(self.dtype)

--- a/scintillometry/convolution.py
+++ b/scintillometry/convolution.py
@@ -93,8 +93,8 @@ class Convolve(ConvolveSamples):
         # Initialize FFTs for fine channelization and the inverse.
         self._FFT = fft_maker.get()
         self._fft = self._FFT(shape=(self._padded_samples_per_frame,) +
-                              self.ih.sample_shape,
-                              sample_rate=self.ih.sample_rate, dtype=self.ih.dtype)
+                              self.ih.sample_shape, dtype=self.ih.dtype,
+                              sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
 
     @lazyproperty

--- a/scintillometry/convolution.py
+++ b/scintillometry/convolution.py
@@ -37,8 +37,8 @@ class ConvolveSamples(PaddedTaskBase):
 
     def __init__(self, ih, response, offset=0, samples_per_frame=None):
         if response.ndim == 1 and ih.ndim > 1:
-            response = response.reshape(response.shape[:1] +
-                                        (1,) * (ih.ndim - 1))
+            response = response.reshape(response.shape[:1]
+                                        + (1,) * (ih.ndim - 1))
         else:
             check_broadcast_to(response, response.shape[:1] + ih.sample_shape)
 
@@ -87,20 +87,21 @@ class Convolve(ConvolveSamples):
     ConvolveSamples : convolution in the time domain (for simple responses)
     scintillometry.fourier.fft_maker : to select the FFT package used.
     """
+
     def __init__(self, ih, response, offset=0, samples_per_frame=None):
         super().__init__(ih, response=response, offset=offset,
                          samples_per_frame=samples_per_frame)
         # Initialize FFTs for fine channelization and the inverse.
         self._FFT = fft_maker.get()
-        self._fft = self._FFT(shape=(self._padded_samples_per_frame,) +
-                              self.ih.sample_shape, dtype=self.ih.dtype,
+        self._fft = self._FFT(shape=(self._padded_samples_per_frame,)
+                              + self.ih.sample_shape, dtype=self.ih.dtype,
                               sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
 
     @lazyproperty
     def _ft_response(self):
-        long_response = np.zeros((self._padded_samples_per_frame,) +
-                                 self._response.shape[1:], self.dtype)
+        long_response = np.zeros((self._padded_samples_per_frame,)
+                                 + self._response.shape[1:], self.dtype)
         long_response[:self._response.shape[0]] = self._response
         fft = self._FFT(shape=long_response.shape, dtype=self.dtype)
         return fft(long_response)

--- a/scintillometry/dispersion.py
+++ b/scintillometry/dispersion.py
@@ -1,7 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE
 
 import numpy as np
-import astropy.units as u
+from astropy import units as u
 from astropy.utils import lazyproperty
 
 from .base import PaddedTaskBase
@@ -98,8 +98,8 @@ class Disperse(PaddedTaskBase):
         # Initialize FFTs for fine channelization and the inverse.
         # TODO: remove duplication with Convolve.
         self._fft = fft_maker(shape=(self._padded_samples_per_frame,) +
-                              self.ih.sample_shape,
-                              sample_rate=self.ih.sample_rate, dtype=self.ih.dtype)
+                              self.ih.sample_shape, dtype=self.ih.dtype,
+                              sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
         self.dm = dm
         self.reference_frequency = reference_frequency

--- a/scintillometry/dispersion.py
+++ b/scintillometry/dispersion.py
@@ -97,8 +97,8 @@ class Disperse(PaddedTaskBase):
 
         # Initialize FFTs for fine channelization and the inverse.
         # TODO: remove duplication with Convolve.
-        self._fft = fft_maker(shape=(self._padded_samples_per_frame,) +
-                              self.ih.sample_shape, dtype=self.ih.dtype,
+        self._fft = fft_maker(shape=(self._padded_samples_per_frame,)
+                              + self.ih.sample_shape, dtype=self.ih.dtype,
                               sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
         self.dm = dm
@@ -117,8 +117,8 @@ class Disperse(PaddedTaskBase):
         # Correct for any time offset applied because the reference frequency
         # was out of range.
         if self._sample_offset != 0:
-            phase_delay += (self._sample_offset / self.sample_rate * u.cycle *
-                            self._fft.frequency)
+            phase_delay += (self._sample_offset / self.sample_rate * u.cycle
+                            * self._fft.frequency)
         phase_factor = np.exp(phase_delay.to_value(u.rad) * 1j)
         phase_factor = phase_factor.astype(self._fft.frequency_dtype,
                                            copy=False)

--- a/scintillometry/fourier/base.py
+++ b/scintillometry/fourier/base.py
@@ -341,8 +341,8 @@ class FFTMakerBase(metaclass=FFTMakerMeta):
 
     def __repr__(self):
         return '{}({})'.format(self.__class__.__name__,
-                               ', '.join(['{k}={v}'.format(k=k, v=v)
-                                          for k, v in self._repr_kwargs.items()]))
+                               ', '.join(['{}={}'.format(k, v) for k, v
+                                          in self._repr_kwargs.items()]))
 
 
 class fft_maker(ScienceState):
@@ -460,7 +460,7 @@ class fft_maker(ScienceState):
             fft_engine = FFT_MAKER_CLASSES[fft_engine](**kwargs)
 
         elif kwargs:
-            raise TypeError("cannot pass keyword arguments except if fft_engine "
-                            "is the name of an FFT maker.")
+            raise TypeError("cannot pass keyword arguments except if "
+                            "fft_engine is the name of an FFT maker.")
 
         return super().set(fft_engine)

--- a/scintillometry/fourier/base.py
+++ b/scintillometry/fourier/base.py
@@ -152,8 +152,8 @@ class FFTBase:
         else:
             frequency = np.fft.fftfreq(a_length, d=(1. / sample_rate))
         # Reshape frequencys to add trailing dimensions.
-        frequency.shape = (frequency.shape +
-                           (len(self._time_shape) - self.axis - 1) * (1,))
+        frequency.shape = (frequency.shape
+                           + (len(self._time_shape) - self.axis - 1) * (1,))
         return frequency
 
     def __call__(self, a):
@@ -198,14 +198,14 @@ class FFTBase:
         return self.__class__(direction=self.direction)
 
     def __eq__(self, other):
-        return (self.direction == other.direction and
-                self.time_shape == other.time_shape and
-                self.time_dtype == other.time_dtype and
-                self.frequency_shape == other.frequency_shape and
-                self.frequency_dtype == other.frequency_dtype and
-                self.axis == other.axis and
-                self.ortho == other.ortho and
-                self.sample_rate == other.sample_rate)
+        return (self.direction == other.direction
+                and self.time_shape == other.time_shape
+                and self.time_dtype == other.time_dtype
+                and self.frequency_shape == other.frequency_shape
+                and self.frequency_dtype == other.frequency_dtype
+                and self.axis == other.axis
+                and self.ortho == other.ortho
+                and self.sample_rate == other.sample_rate)
 
     def __repr__(self):
         return ("<{s.__class__.__name__}"

--- a/scintillometry/fourier/numpy.py
+++ b/scintillometry/fourier/numpy.py
@@ -20,6 +20,7 @@ class NumpyFFTBase(FFTBase):
     direction : 'forward' or 'backward', optional
         Direction of the FFT.
     """
+
     def __init__(self, direction='forward'):
         super().__init__(direction=direction)
         time_complex = self._time_dtype.kind == 'c'

--- a/scintillometry/fourier/numpy.py
+++ b/scintillometry/fourier/numpy.py
@@ -2,7 +2,7 @@
 """FFT maker and class using the `numpy.fft` routines."""
 
 import numpy as np
-import operator
+
 from .base import FFTMakerBase, FFTBase
 
 

--- a/scintillometry/fourier/pyfftw.py
+++ b/scintillometry/fourier/pyfftw.py
@@ -10,9 +10,8 @@ backward transforms (if created using :meth:`PyfftwFFTBase.inverse`)
 
 """
 
-import operator
-import numpy as np
 import pyfftw
+
 from .base import FFTMakerBase, FFTBase
 
 

--- a/scintillometry/fourier/tests/test_fourier.py
+++ b/scintillometry/fourier/tests/test_fourier.py
@@ -55,9 +55,9 @@ class TestFFTClasses:
         self.y_r2D = np.random.uniform(low=-13., high=29., size=(100, 25))
         # 3D complex random.
         self.y_3D = (np.random.uniform(low=-19., high=16.,
-                                       size=(100, 10, 30)) +
-                     1.j * np.random.uniform(low=-13., high=23.,
-                                             size=(100, 10, 30)))
+                                       size=(100, 10, 30))
+                     + 1.j * np.random.uniform(low=-13., high=23.,
+                                               size=(100, 10, 30)))
 
         # Transforms of the above.
         self.Y_exp = np.fft.fft(self.y_exp)

--- a/scintillometry/functions.py
+++ b/scintillometry/functions.py
@@ -73,6 +73,7 @@ class Power(TaskBase):
         If the underlying stream is not complex, the number of polarizations
         not equal to two, or the polarization labels not unique.
     """
+
     def __init__(self, ih, polarization=None):
         if polarization is None:
             polarization = ih.polarization

--- a/scintillometry/functions.py
+++ b/scintillometry/functions.py
@@ -99,7 +99,8 @@ class Power(TaskBase):
             raise ValueError("{} only works on a complex timestream.")
         dtype = np.zeros(1, ih_dtype).real.dtype
 
-        super().__init__(ih, shape=shape, polarization=polarization, dtype=dtype)
+        super().__init__(ih, shape=shape, polarization=polarization,
+                         dtype=dtype)
 
     def task(self, data):
         """Calculate the polarization powers and cross terms for one frame."""

--- a/scintillometry/generators.py
+++ b/scintillometry/generators.py
@@ -9,15 +9,16 @@ import numpy as np
 from .base import Base
 
 
-__all__ = ['StreamGenerator', 'EmptyStreamGenerator', 'Noise', 'NoiseGenerator']
+__all__ = ['StreamGenerator', 'EmptyStreamGenerator',
+           'Noise', 'NoiseGenerator']
 
 
 class StreamGenerator(Base):
     """Generator of data produced by a user-provided function.
 
-    The function needs to be aware of stream structure.  As an alternative, generate
-    an empty stream with `~scintillometry.generators.EmptyStreamGenerator` and add a
-    `~scintillometry.base.Task` that fills data arrays.
+    The function needs to be aware of stream structure.  As an alternative,
+    use `~scintillometry.generators.EmptyStreamGenerator` to generate an empty
+    stream and add a `~scintillometry.base.Task` that fills data arrays.
 
     Parameters
     ----------
@@ -34,8 +35,8 @@ class StreamGenerator(Base):
     sample_rate : `~astropy.units.Quantity`
         Sample rate, in units of frequency.
     samples_per_frame : int
-        Blocking factor.  This can be used for efficiency to reduce the overhead
-        of calling the source function.
+        Blocking factor.  This can be used for efficiency to reduce the
+        overhead of calling the source function.
     frequency : `~astropy.units.Quantity`, optional
         Frequencies for each channel.  Should be broadcastable to the
         sample shape.  Default: unknown.
@@ -55,11 +56,12 @@ class StreamGenerator(Base):
 
     >>> from scintillometry.generators import StreamGenerator
     >>> import numpy as np
-    >>> from astropy import time as t, units as u
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
     >>> def alternate(sh):
     ...     return np.full((1,) + sh.shape[1:], sh.tell() % 2 == 1, sh.dtype)
     ...
-    >>> sh = StreamGenerator(alternate, (10, 6), t.Time('2010-11-12'), 10.*u.Hz)
+    >>> sh = StreamGenerator(alternate, (10, 6), Time('2010-11-12'), 10.*u.Hz)
     >>> sh.seek(5)
     5
     >>> sh.read()  # doctest: +FLOAT_CMP
@@ -68,6 +70,7 @@ class StreamGenerator(Base):
            [1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j],
            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
            [1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j]], dtype=complex64)
+
     """
     def __init__(self, function, shape, start_time, sample_rate,
                  samples_per_frame=1, frequency=None, sideband=None,

--- a/scintillometry/generators.py
+++ b/scintillometry/generators.py
@@ -72,6 +72,7 @@ class StreamGenerator(Base):
            [1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j]], dtype=complex64)
 
     """
+
     def __init__(self, function, shape, start_time, sample_rate,
                  samples_per_frame=1, frequency=None, sideband=None,
                  polarization=None, dtype=np.complex64):
@@ -140,6 +141,7 @@ class EmptyStreamGenerator(Base):
     >>> sh.read()  # doctest: +FLOAT_CMP
     array([ 1., -1.,  1., -1.,  1.], dtype=float32)
     """
+
     def _read_frame(self, frame_index):
         return np.empty((self.samples_per_frame,) + self.shape[1:],
                         self.dtype)
@@ -163,6 +165,7 @@ class Noise:
     Data is identical between invocations only if seeded identically *and*
     read in the same order.
     """
+
     def __init__(self, seed=None):
         # TODO: replace with new Generator class for numpy >=1.17.
         self._random_state = np.random.RandomState(seed)
@@ -235,6 +238,7 @@ class NoiseGenerator(StreamGenerator):
     first access of frames is done in the same order, with the same number of
     samples per frame.
     """
+
     def __init__(self, shape, start_time, sample_rate, samples_per_frame,
                  frequency=None, sideband=None, polarization=None,
                  dtype=np.complex64, seed=None):

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -20,6 +20,7 @@ class _FakeOutput(ShapedLikeNDArray):
     It subclasses `~astropy.utils.ShapedLikeNDArray` to mimic all the
     shape properties of `~numpy.ndarray` given a (fake) shape.
     """
+
     def __init__(self, shape, setitem):
         self._shape = shape
         self._setitem = setitem
@@ -96,6 +97,7 @@ class Integrate(BaseTaskBase):
     .. warning: The format for ``average=False`` may change in the future.
 
     """
+
     def __init__(self, ih, step=None, phase=None, *,
                  start=0, average=True, samples_per_frame=1, dtype=None):
         ih_start = ih.seek(start)
@@ -119,8 +121,8 @@ class Integrate(BaseTaskBase):
         else:
             try:
                 # We may not be at an integer sample.
-                ih_start += ((start - ih.time) *
-                             ih.sample_rate).to_value(u.one)
+                ih_start += ((start - ih.time)
+                             * ih.sample_rate).to_value(u.one)
             except TypeError:  # start is not a Time
                 start = ih.time
             start_time = start
@@ -197,8 +199,8 @@ class Integrate(BaseTaskBase):
         Phase is assumed to increase monotonously with time.
         """
         if self._phase is None:
-            return (np.around(samples / self._mean_offset_size +
-                              self._ih_start).astype(int))
+            return (np.around(samples / self._mean_offset_size
+                              + self._ih_start).astype(int))
 
         # Requested phases relative to start (we work relative to the start
         # to avoid rounding errors for large cycle counts).  Also, we want
@@ -227,8 +229,8 @@ class Integrate(BaseTaskBase):
             ih_time = self.ih.start_time + old_offsets / self.ih.sample_rate
             # TODO: the conversion is necessary because Quantity(Phase)
             # doesn't convert the two doubles to float internally.
-            ih_phase[mask] = (self._phase(ih_time) -
-                              self._start).astype(ih_phase.dtype, copy=False)
+            ih_phase[mask] = (self._phase(ih_time)
+                              - self._start).astype(ih_phase.dtype, copy=False)
             # Next, interpolate in known phases to get improved offsets.
             offsets[mask] = np.interp(phase[mask], all_ih_phase, all_offsets)
             # Finally, update mask.
@@ -254,8 +256,8 @@ class Integrate(BaseTaskBase):
         # Get offsets in the underlying stream for the current samples (and
         # the next one to get the upper edge). For integration over time
         # intervals, these offsets are not necessarily evenly spaced.
-        samples = (frame_index * self.samples_per_frame +
-                   np.arange(self.samples_per_frame + 1))
+        samples = (frame_index * self.samples_per_frame
+                   + np.arange(self.samples_per_frame + 1))
         offsets = self._get_offsets(samples)
         self.ih.seek(offsets[0])
         offsets -= offsets[0]
@@ -272,8 +274,8 @@ class Integrate(BaseTaskBase):
             ndim_ih_sample = len(self.ih.sample_shape)
             self._frame = {
                 'data': frame,
-                'count': np.zeros(frame.shape[:-ndim_ih_sample] +
-                                  (1,) * ndim_ih_sample, dtype=int)}
+                'count': np.zeros(frame.shape[:-ndim_ih_sample]
+                                  + (1,)*ndim_ih_sample, dtype=int)}
         else:
             self._frame = frame
         self._offsets = offsets
@@ -369,6 +371,7 @@ class Fold(Integrate):
     .. warning: The format for ``average=False`` may change in the future.
 
     """
+
     def __init__(self, ih, n_phase, phase, step=None, *,
                  start=0, average=True, samples_per_frame=1, dtype=None):
         super().__init__(ih, step=step, start=start, average=average,
@@ -396,8 +399,8 @@ class Fold(Integrate):
 
         # TODO: allow having a phase reference.
         phases = self.phase(self._raw_time + raw_items / self.ih.sample_rate)
-        phase_index = ((phases % (1. * u.cycle)).to_value(u.cycle) *
-                       self.n_phase).astype(int)
+        phase_index = ((phases % (1. * u.cycle)).to_value(u.cycle)
+                       * self.n_phase).astype(int)
         # Do the actual folding, adding the data to the sums and counts.
         # TODO: np.add.at is not very efficient; replace?
         np.add.at(self._frame['data'], (sample_index, phase_index), raw)
@@ -454,6 +457,7 @@ class Stack(BaseTaskBase):
     .. warning: The format for ``average=False`` may change in the future.
 
     """
+
     def __init__(self, ih, n_phase, phase, *,
                  start=0, average=True, samples_per_frame=1, dtype=None):
         # Set up the integration in phase bins.

--- a/scintillometry/integration.py
+++ b/scintillometry/integration.py
@@ -5,7 +5,7 @@ import operator
 import warnings
 
 import numpy as np
-import astropy.units as u
+from astropy import units as u
 from astropy.utils import ShapedLikeNDArray, lazyproperty
 
 from .base import BaseTaskBase
@@ -119,7 +119,8 @@ class Integrate(BaseTaskBase):
         else:
             try:
                 # We may not be at an integer sample.
-                ih_start += ((start - ih.time) * ih.sample_rate).to_value(u.one)
+                ih_start += ((start - ih.time) *
+                             ih.sample_rate).to_value(u.one)
             except TypeError:  # start is not a Time
                 start = ih.time
             start_time = start
@@ -208,7 +209,7 @@ class Integrate(BaseTaskBase):
         offsets = (phase / ih_mean_phase_size).to_value(u.one)
         # In order to update guesses, below we interpolate phase in offset.
         # Add known boundaries to ensure we do not go out of bounds there.
-        all_offsets = np.hstack((0, offsets, self.ih.shape[0] - self._ih_start))
+        all_offsets = np.hstack((0, offsets, self.ih.shape[0]-self._ih_start))
         # Associated phases relative to start phase;
         # all but start (=0) and stop will be overwritten.
         all_ih_phase = all_offsets * ih_mean_phase_size

--- a/scintillometry/io/__init__.py
+++ b/scintillometry/io/__init__.py
@@ -3,4 +3,4 @@
 
 Presently, the open function only deals with PSRFITS files.
 """
-from .psrfits import open
+from .psrfits import open  # noqa

--- a/scintillometry/io/psrfits/__init__.py
+++ b/scintillometry/io/psrfits/__init__.py
@@ -1,3 +1,3 @@
 # Licensed under the GPLv3 - see LICENSE
-from .core import *
-from .hdu import *
+from .core import *  # noqa
+from .hdu import *  # noqa

--- a/scintillometry/io/psrfits/core.py
+++ b/scintillometry/io/psrfits/core.py
@@ -136,6 +136,7 @@ class PSRFITSReader(BaseTaskBase):
     """
     # Note: this very light-weight wrapper around SubintHDU is mostly here
     # because eventually it might unify different/multiple HDUs.
+
     def __init__(self, ih, frequency=None, sideband=None, polarization=None,
                  dtype=None, weighted=True):
         self.weighted = weighted
@@ -169,6 +170,7 @@ class PSRFITSWriter:
     -----
     Currently it only support write the PSRFITS primary HDU and Subint HDU.
     """
+
     def __init__(self, filename, ih, hdus=None):
         self.filename = filename
         self.ih = ih

--- a/scintillometry/io/psrfits/core.py
+++ b/scintillometry/io/psrfits/core.py
@@ -1,11 +1,12 @@
 # Licensed under the GPLv3 - see LICENSE
 """Interfaces for dealing with PSRFITS fold-mode data."""
 
-from ...base import BaseTaskBase
 from astropy.io import fits
-from .hdu import HDU_map
 from astropy import log
 from collections import defaultdict
+
+from scintillometry.base import BaseTaskBase
+from .hdu import HDU_map
 
 
 __all__ = ['open', 'get_readers', 'PSRFITSReader']
@@ -86,8 +87,8 @@ def get_readers(hdu_list, **kwargs):
         if hdu.name in HDU_map.keys():
             buffers[hdu.name].append(hdu)
         else:
-            log.warning("Skipping HDU {} ({}), as it is not a supported PSRFITS"
-                        " HDU.".format(ii, hdu.name))
+            log.warning("Skipping HDU {} ({}), as it is not a supported "
+                        "PSRFITS HDU.".format(ii, hdu.name))
 
     primary = buffers.pop('PRIMARY', [])
     if len(primary) != 1:

--- a/scintillometry/io/psrfits/hdu.py
+++ b/scintillometry/io/psrfits/hdu.py
@@ -103,10 +103,10 @@ class PSRFITSPrimaryHDU(HDUWrapper):
     @property
     def start_time(self):
         return (Time(float(self.header['STT_IMJD']), format='mjd', precision=9,
-                     location=self.location) +
-                TimeDelta(float(self.header['STT_SMJD']),
-                          float(self.header['STT_OFFS']),
-                          format='sec', scale='tai'))
+                     location=self.location)
+                + TimeDelta(float(self.header['STT_SMJD']),
+                            float(self.header['STT_OFFS']),
+                            format='sec', scale='tai'))
 
     @start_time.setter
     def start_time(self, time):
@@ -146,8 +146,8 @@ class PSRFITSPrimaryHDU(HDUWrapper):
         # (n_chan + 1) // 2 to ensure this makes sense for n_chan = 1
         # and is consistent with the document at least for even n_chan.
 
-        freq = c_freq + (np.arange(1, n_chan + 1) -
-                         ((n_chan + 1) // 2)) * chan_bw
+        freq = c_freq + (np.arange(1, n_chan + 1)
+                         - ((n_chan + 1) // 2)) * chan_bw
         return u.Quantity(freq, u.MHz, copy=False)
 
     @frequency.setter
@@ -263,9 +263,9 @@ class SubintHDU(HDUWrapper):
     @property
     def _has_data(self):
         # TODO: surely there is a better way...
-        return (self.hdu._file is not None or
-                self.hdu._buffer is not None or
-                self.hdu._has_data)
+        return (self.hdu._file is not None
+                or self.hdu._buffer is not None
+                or self.hdu._has_data)
 
     @property
     def data(self):
@@ -363,8 +363,8 @@ class SubintHDU(HDUWrapper):
         pol_type = self.header['POL_TYPE']
         # split into equal parts using zip;
         # see https://docs.python.org/3.5/library/functions.html#zip
-        return np.array([map(''.join, zip(*[iter(self.header['POL_TYPE'])] *
-                                          (len(pol_type) // self.npol)))])
+        return np.array([map(''.join, zip(*[iter(self.header['POL_TYPE'])]
+                                          * (len(pol_type) // self.npol)))])
 
     @polarization.setter
     def polarization(self, value):
@@ -462,6 +462,7 @@ class PSRSubintHDU(SubintHDU):
     Right now we are assuming the data rows are continuous in time and the
     frequency are the same.
     """
+
     def verify(self):
         super().verify()
         assert self.mode.upper() == 'PSR', \
@@ -501,8 +502,8 @@ class PSRSubintHDU(SubintHDU):
         """
         start_time = super().start_time
         if "OFFS_SUB" in self.data.names:
-            offset0 = (self.data['OFFS_SUB'][0] -
-                       self.data['TSUBINT'][0] * self.samples_per_frame / 2)
+            offset0 = (self.data['OFFS_SUB'][0]
+                       - self.data['TSUBINT'][0] * self.samples_per_frame / 2)
             start_time += u.Quantity(offset0, u.s, copy=False)
 
         return start_time

--- a/scintillometry/io/psrfits/psrfits_htm_parser.py
+++ b/scintillometry/io/psrfits/psrfits_htm_parser.py
@@ -54,9 +54,9 @@ class MyHTMLParser(HTMLParser):
         self.collect = False
         data = self.data
         if tag == 'p' and (
-                data.startswith('COMMENT') or
-                data.startswith('END') or
-                (len(data) > 8 and data[8] == '=')):
+                data.startswith('COMMENT')
+                or data.startswith('END')
+                or (len(data) > 8 and data[8] == '=')):
             if data.startswith('EXTNAME'):
                 self.extname = data.split(' ')[2]
             self.headers += data.split('\n')

--- a/scintillometry/phases/__init__.py
+++ b/scintillometry/phases/__init__.py
@@ -1,3 +1,3 @@
-from .core import PintPhase, PolycoPhase
-from .phase import Phase, FractionalPhase
-from .predictor import Polyco
+from .core import PintPhase, PolycoPhase  # noqa
+from .phase import Phase, FractionalPhase  # noqa
+from .predictor import Polyco  # noqa

--- a/scintillometry/phases/core.py
+++ b/scintillometry/phases/core.py
@@ -35,6 +35,7 @@ class PintPhase:
     This method provides high precision phase calculation(~10 Nanosecond
     timing precision).
     """
+
     def __init__(self, par_file, observatory, frequency, **kwargs):
         from pint.models import get_model
 
@@ -89,6 +90,7 @@ class PolycoPhase:
     polyco_file : str
         Tempo style polyco file.
     """
+
     def __init__(self, polyco_file):
         self.polyco = Polyco(polyco_file)
 

--- a/scintillometry/phases/core.py
+++ b/scintillometry/phases/core.py
@@ -2,10 +2,8 @@
 """Phase_utils.py defines the phase calculation utility class. Currently, the
 pulse phase at a given time can be computed by PINT or polycos.
 """
-import warnings
 
-import numpy as np
-import astropy.units as u
+from astropy import units as u
 
 from .phase import Phase
 from .predictor import Polyco

--- a/scintillometry/phases/phase.py
+++ b/scintillometry/phases/phase.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under the GPLv3 - see LICENSE
 """Provide a Phase class with integer and fractional part."""
-import operator
 
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import Angle, Longitude
-from astropy.time import Time
 from astropy.time.utils import two_sum, two_product
 from astropy.utils import minversion
 
@@ -151,15 +149,15 @@ class FractionalPhase(Longitude):
         unit.  Default is 'cycle'.
     wrap_angle : :class:`~astropy.coordinates.Angle` or equivalent, optional
         Angle at which to wrap back to ``wrap_angle - 1 cycle``.
-        If ``None`` (default), it will be taken to be 0.5 cycle unless ``angle``
-        has a ``wrap_angle`` attribute.
+        If ``None`` (default), it will be taken to be 0.5 cycle unless
+        ``angle`` has a ``wrap_angle`` attribute.
 
     Raises
     ------
     `~astropy.units.UnitsError`
         If a unit is not provided or it is not an angular unit.
     `TypeError`
-        If the angle parameter is an instance of :class:`~astropy.coordinates.Latitude`.
+        If the angle parameter is a :class:`~astropy.coordinates.Latitude`.
     """
     _default_wrap_angle = Angle(0.5, u.cycle)
     _equivalent_unit = _default_unit = u.cycle
@@ -260,19 +258,22 @@ class Phase(Angle):
         if phase2 is not None:
             if isinstance(phase2, Phase):
                 phase2 = phase2 + phase1
-                return phase2 if subok or type(phase2) is cls else phase2.view(cls)
-            else:
-                phase2 = Angle(phase2, cls._unit, copy=False)
+                if not subok and type(phase2) is not cls:
+                    phase2 = phase2.view(cls)
+                return phase2
+
+            phase2 = Angle(phase2, cls._unit, copy=False)
 
         return cls.from_angles(phase1, phase2)
 
     @classmethod
-    def from_angles(cls, phase1, phase2=None, factor=None, divisor=None, out=None):
+    def from_angles(cls, phase1, phase2=None, factor=None, divisor=None,
+                    out=None):
         """Create a Phase instance from two angles.
 
-        The two angles will be added, and possibly multiplied by a factor or divided
-        by a divisor, preserving precision using two doubles, one for the integer
-        part and one for the remainder.
+        The two angles will be added, and possibly multiplied by a factor or
+        divided by a divisor, preserving precision using two doubles, one for
+        the integer part and one for the remainder.
 
         Note that this class method is mostly meant for internal use.
 
@@ -620,7 +621,7 @@ class Phase(Angle):
         """
         return self._take_along_axis(self.argsort(axis), axis, keepdims=True)
 
-    # Quantity lets ndarray.__eq__, __ne__ deal with structured arrays (like us).
+    # Quantity lets ndarray.__eq__, __ne__ deal with structured arrays like us.
     # Override this so we can deal with it in __array_ufunc__.
     def __eq__(self, other):
         try:
@@ -654,11 +655,11 @@ class Phase(Angle):
 
         Returns
         -------
-        result : `~scintillometry.phases.Phase`, `~astropy.units.Quantity`, or `~numpy.ndarray`
+        result : array_like
             Results of the ufunc, with the unit set properly,
-            `~scintillometry.phases.phase` if possible (i.e., units of cycles,
-            others `~astropyy.units.Quantity` or `~numpy.ndarray` as
-            appropriate.
+            `~scintillometry.phases.Phase` if possible (i.e., with units of
+            cycles), otherwise `~astropyy.units.Quantity` or `~numpy.ndarray`
+            as appropriate.
         """
         # Do *not* use inputs.index(self) since that will use __eq__
         for i_self, input_ in enumerate(inputs):
@@ -819,7 +820,8 @@ class Phase(Angle):
 
         return super()._new_view(obj, unit)
 
-    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):
+    def astype(self, dtype, order='K', casting='unsafe', subok=True,
+               copy=True):
         """Copy of the array, cast to a specified type.
 
         As `numpy.ndarray.astype`, but using knowledge of format to cast to

--- a/scintillometry/phases/phase.py
+++ b/scintillometry/phases/phase.py
@@ -363,9 +363,9 @@ class Phase(Angle):
         if unit is None or unit != self._unit:
             raise u.UnitTypeError(
                 "{0} instances require units of '{1}'"
-                .format(type(self).__name__, self._unit) +
-                (", but no unit was given." if unit is None else
-                 ", so cannot set it to '{0}'.".format(unit)))
+                .format(type(self).__name__, self._unit)
+                + (", but no unit was given." if unit is None else
+                   ", so cannot set it to '{0}'.".format(unit)))
 
         super()._set_unit(unit)
 
@@ -437,8 +437,9 @@ class Phase(Angle):
                 # guarantee that the right number of digits is shown.
                 frac_str = func(frac+0.25)
                 f24 = int(frac_str[2:4])
-                if func is str and (len(frac_str) == 3 or
-                                    len(frac_str) == 4 and frac_str[3] == '5'):
+                if func is str and (len(frac_str) == 3
+                                    or (len(frac_str) == 4
+                                        and frac_str[3] == '5')):
                     if len(frac_str) == 3:
                         f24 = '{:02d}'.format(f24 * 10 - 25)
                     else:
@@ -603,8 +604,8 @@ class Phase(Angle):
         """
         if out is not None:
             raise ValueError("An `out` argument is not yet supported.")
-        return (self.max(axis, keepdims=keepdims) -
-                self.min(axis, keepdims=keepdims))
+        return (self.max(axis, keepdims=keepdims)
+                - self.min(axis, keepdims=keepdims))
 
     def sort(self, axis=-1):
         """Return a copy sorted along the specified axis.
@@ -714,8 +715,9 @@ class Phase(Angle):
                 diff = (v0['int'] - v1['int']) + (v0['frac'] - v1['frac'])
                 return getattr(function, method)(diff, 0, **kwargs)
 
-        elif ((function is np.multiply or
-               function is np.divide and i_self == 0) and basic_phase_out):
+        elif ((function is np.multiply
+               or function is np.divide and i_self == 0)
+              and basic_phase_out):
             try:
                 other = u.Quantity(inputs[1-i_self], u.dimensionless_unscaled,
                                    copy=False).value
@@ -731,8 +733,8 @@ class Phase(Angle):
                 # downgrading ourself to a quantity and see if things work.
                 pass
 
-        elif (function in {np.floor_divide, np.remainder, np.divmod} and
-              basic_real):
+        elif (function in {np.floor_divide, np.remainder, np.divmod}
+              and basic_real):
             fd_out = None
             if out is not None:
                 if function is np.divmod:

--- a/scintillometry/phases/pint_toas.py
+++ b/scintillometry/phases/pint_toas.py
@@ -3,10 +3,8 @@
 
 See https://github.com/nanograv/PINT
 """
-import warnings
 
 import numpy as np
-from astropy import units as u
 
 
 __all__ = ['PintToas']

--- a/scintillometry/phases/pint_toas.py
+++ b/scintillometry/phases/pint_toas.py
@@ -51,6 +51,7 @@ class PintToas:
     Combined with metadata, it can be considered a timestamp
     (e.g., observatory, observing frequency, etc.)
     """
+
     def __init__(self, observatory, frequency, *,
                  ephemeris='jpl', include_bipm=True, bipm_version='BIPM2015',
                  include_gps=True, planets=False, tdb_method="default",

--- a/scintillometry/phases/predictor.py
+++ b/scintillometry/phases/predictor.py
@@ -10,7 +10,7 @@ Examples
 
 For use with folding codes with times since some start time t0 in seconds:
 
->>> psr_polyco.phasepol(t0, 'fraction', t0=t0, time_unit=u.second, convert=True)
+>>> psr_polyco.phasepol(t0, 'fraction', t0=t0, time_unit=u.s, convert=True)
 
 Notes
 -----
@@ -49,8 +49,7 @@ Example tempo2 call to produce one:
 
 .. code-block:: text
 
-    tempo2 -tempo1 \
-        -f ~/packages/scintellometry/scintellometry/ephemerides/psrb1957+20.par \
+    tempo2 -tempo1 -f psrb1957+20.par \
         -polyco "56499 56500 300 12 12 aro 150.0"
                  |-- MJD start
                        |-- MJD end
@@ -60,8 +59,6 @@ Example tempo2 call to produce one:
                                        |-- Observatory
                                            |-- Frequency in MHz
 """
-
-from __future__ import division, print_function
 
 from collections import OrderedDict
 
@@ -105,7 +102,8 @@ class Polyco(QTable):
             Package which the writer should emulate.  Default: 'tempo2'
         """
         header_fmt = ''.join(
-            [('{' + key + converter['fmt'] + ('}\n' if key == 'lgrms' else '}'))
+            [('{' + key + converter['fmt'] +
+              ('}\n' if key == 'lgrms' else '}'))
              for key, converter in converters.items()
              if key in self.keys() or key in ('date', 'utc_mid')])
 

--- a/scintillometry/phases/predictor.py
+++ b/scintillometry/phases/predictor.py
@@ -102,8 +102,7 @@ class Polyco(QTable):
             Package which the writer should emulate.  Default: 'tempo2'
         """
         header_fmt = ''.join(
-            [('{' + key + converter['fmt'] +
-              ('}\n' if key == 'lgrms' else '}'))
+            ['{' + key + converter['fmt'] + ('}\n' if key == 'lgrms' else '}')
              for key, converter in converters.items()
              if key in self.keys() or key in ('date', 'utc_mid')])
 

--- a/scintillometry/sampling.py
+++ b/scintillometry/sampling.py
@@ -73,7 +73,8 @@ class Resample(PaddedTaskBase):
       >>> from baseband import data, vdif
       >>> fh = vdif.open(data.SAMPLE_VDIF)
       >>> texact = Time('2014-06-16T05:56:07.000123456')
-      >>> ((texact - fh.start_time) * fh.sample_rate).to(1)  # doctest: +FLOAT_CMP
+      >>> ((texact - fh.start_time) * fh.sample_rate).to(1)
+      ... # doctest: +FLOAT_CMP
       <Quantity 3950.59201992>
       >>> rh = Resample(fh, texact)
       >>> rh.time.isot

--- a/scintillometry/sampling.py
+++ b/scintillometry/sampling.py
@@ -101,6 +101,7 @@ class Resample(PaddedTaskBase):
              -3.316505,  1.      ], dtype=float32)
       >>> fh.close()
     """
+
     def __init__(self, ih, offset, whence='start', *,
                  samples_per_frame=None):
 
@@ -118,8 +119,8 @@ class Resample(PaddedTaskBase):
         super().__init__(ih, pad_start=pad_start, pad_end=pad_end,
                          samples_per_frame=samples_per_frame)
 
-        self._fft = fft_maker(shape=(self._padded_samples_per_frame,) +
-                              ih.sample_shape, sample_rate=ih.sample_rate,
+        self._fft = fft_maker(shape=(self._padded_samples_per_frame,)
+                              + ih.sample_shape, sample_rate=ih.sample_rate,
                               dtype=ih.dtype)
         self._ifft = self._fft.inverse()
 
@@ -132,8 +133,8 @@ class Resample(PaddedTaskBase):
     @lazyproperty
     def phase_factor(self):
         """Phase offsets of the Fourier-transformed frame."""
-        phase_delay = (self._fraction / self.sample_rate * u.cycle *
-                       self._fft.frequency)
+        phase_delay = (self._fraction / self.sample_rate * u.cycle
+                       * self._fft.frequency)
         phase_factor = np.exp(phase_delay.to_value(u.rad) * 1j)
         phase_factor = phase_factor.astype(self._fft.frequency_dtype,
                                            copy=False)

--- a/scintillometry/shaping.py
+++ b/scintillometry/shaping.py
@@ -22,6 +22,7 @@ class ChangeSampleShapeBase(TaskBase):
     ih : task or `baseband` stream reader
         Input data stream.
     """
+
     def __init__(self, ih):
         # Check operation is possible
         a = np.empty((7,) + ih.sample_shape, dtype='?')
@@ -104,6 +105,7 @@ class ChangeSampleShape(Task, ChangeSampleShapeBase):
     """
     # Override __init__ only to get rid of kwargs of Task, since these cannot
     # be passed on to ChangeSampleShapeBase anyway.
+
     def __init__(self, ih, task, method=None):
         super().__init__(ih, task, method=method)
 
@@ -328,6 +330,7 @@ class GetItem(ChangeSampleShapeBase):
         array(1, dtype=int8)
         >>> fh.close()
     """
+
     def __init__(self, ih, item):
         if isinstance(item, tuple):
             self._item = (slice(None),) + item

--- a/scintillometry/tests/test_base.py
+++ b/scintillometry/tests/test_base.py
@@ -56,6 +56,7 @@ class SquareHat(PaddedTaskBase):
 
     `SquareHat` simply convolves with a set of 1s of given length.
     """
+
     def __init__(self, ih, n, offset=0, samples_per_frame=None):
         self._n = n
         super().__init__(ih, pad_start=n-1-offset, pad_end=offset,
@@ -169,8 +170,8 @@ class TestTaskBase(UseVDIFSample):
         assert rt.ndim == fh.ndim + 1
         assert rt.tell() == 0
         assert rt.tell(unit='time') == rt.time == rt.start_time
-        assert abs(rt.stop_time - rt.start_time -
-                   (nsample * n) / fh.sample_rate) < 1*u.ns
+        assert abs(rt.stop_time
+                   - rt.start_time - (nsample * n) / fh.sample_rate) < 1*u.ns
 
         # Get reference data.
         ref_data = fh.read(nsample * n).reshape((-1, n) + fh.sample_shape)
@@ -181,8 +182,8 @@ class TestTaskBase(UseVDIFSample):
         # Check sequential reading.
         data1 = rt.read()
         assert rt.tell() == rt.shape[0]
-        assert abs(rt.time - rt.start_time -
-                   rt.shape[0] / rt.sample_rate) < 1*u.ns
+        assert abs(rt.time
+                   - rt.start_time - rt.shape[0] / rt.sample_rate) < 1*u.ns
         assert rt.dtype is data1.dtype
         assert np.all(ref_data == data1)
 
@@ -339,8 +340,8 @@ class TestTasks(UseVDIFSample):
         # Apply to everything.
         data1 = ft.read()
         assert ft.tell() == ft.shape[0]
-        assert (ft.time - ft.start_time -
-                ft.shape[0] / ft.sample_rate) < 1*u.ns
+        assert abs(ft.time
+                   - ft.start_time - ft.shape[0] / ft.sample_rate) < 1*u.ns
         assert ft.dtype is ref_data.dtype is data1.dtype
         assert np.allclose(ref_data, data1)
 
@@ -399,8 +400,8 @@ class TestPaddedTaskBase(UseVDIFSample):
         expected_size = ((fh.shape[0] - 2) // 4) * 4
         assert sh.sample_rate == fh.sample_rate
         assert sh.shape == (expected_size,) + fh.shape[1:]
-        assert abs(sh.start_time - fh.start_time -
-                   2. / fh.sample_rate) < 1. * u.ns
+        assert abs(sh.start_time
+                   - fh.start_time - 2. / fh.sample_rate) < 1. * u.ns
         raw = fh.read(12)
         expected = raw[:-2] + raw[1:-1] + raw[2:]
         data = sh.read(10)

--- a/scintillometry/tests/test_channelize.py
+++ b/scintillometry/tests/test_channelize.py
@@ -32,8 +32,8 @@ class TestChannelizeReal(UseVDIFSample):
         # Note: sideband is actually incorrect for this VDIF file;
         # this is for testing only.
         self.ref_sideband = np.tile([-1, 1], 4)
-        self.ref_frequency = ((311.25 + 16 * (np.arange(8) // 2)) * u.MHz +
-                              self.ref_sideband * rfft.frequency)
+        self.ref_frequency = ((311.25 + 16 * (np.arange(8) // 2)) * u.MHz
+                              + self.ref_sideband * rfft.frequency)
         self.fh_freq = SetAttribute(
             self.fh,
             frequency=311.25*u.MHz+(np.arange(8.)//2)*16.*u.MHz,
@@ -46,8 +46,8 @@ class TestChannelizeReal(UseVDIFSample):
         # Channelize everything.
         data1 = ct.read()
         assert ct.tell() == ct.shape[0]
-        assert (ct.time - ct.start_time -
-                ct.shape[0] / ct.sample_rate) < 1*u.ns
+        assert (ct.time - ct.start_time
+                - ct.shape[0] / ct.sample_rate) < 1*u.ns
         assert ct.dtype is self.ref_data.dtype is data1.dtype
         assert np.all(self.ref_data == data1)
 
@@ -121,16 +121,16 @@ class TestChannelizeComplex(UseDADASample):
         """Test frequency calculation."""
         fh = self.fh_freq
         ct = Channelize(fh, self.n)
-        ref_frequency = (320. * u.MHz +
-                         np.fft.fftfreq(self.n, 1. / fh.sample_rate))
+        ref_frequency = (320. * u.MHz
+                         + np.fft.fftfreq(self.n, 1. / fh.sample_rate))
         assert np.all(ct.sideband == fh.sideband)
         assert np.all(ct.frequency == ref_frequency[:, np.newaxis])
 
         fh = SetAttribute(self.fh, frequency=self.fh_freq.frequency,
                           sideband=-self.fh_freq.sideband)
         ct = Channelize(fh, self.n)
-        ref_frequency = (320. * u.MHz -
-                         np.fft.fftfreq(self.n, 1. / fh.sample_rate))
+        ref_frequency = (320. * u.MHz
+                         - np.fft.fftfreq(self.n, 1. / fh.sample_rate))
         assert np.all(ct.sideband == fh.sideband)
         assert np.all(ct.frequency == ref_frequency[:, np.newaxis])
 

--- a/scintillometry/tests/test_combining.py
+++ b/scintillometry/tests/test_combining.py
@@ -3,7 +3,6 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
-import astropy.units as u
 
 from ..base import SetAttribute
 from ..shaping import GetItem, Reshape

--- a/scintillometry/tests/test_conversion.py
+++ b/scintillometry/tests/test_conversion.py
@@ -61,8 +61,8 @@ def test_real_to_complex_sine(f_nyquist):
 
     def real_sine(handle):
 
-        real_sine = np.sin(f_nyquist * np.pi *
-                           np.arange(handle.samples_per_frame))
+        real_sine = np.sin(f_nyquist * np.pi
+                           * np.arange(handle.samples_per_frame))
         return real_sine
 
     sine_fh = StreamGenerator(real_sine,
@@ -75,8 +75,8 @@ def test_real_to_complex_sine(f_nyquist):
                               dtype='f8')
 
     f_complex = f_nyquist - 0.5
-    complex_dc = np.exp(2j * np.pi *
-                        (-0.25 + np.arange(2048 // 2) * f_complex))
+    complex_dc = np.exp(2j * np.pi
+                        * (-0.25 + np.arange(2048 // 2) * f_complex))
 
     real2complex = Real2Complex(sine_fh)
     complex_signal = real2complex.read()

--- a/scintillometry/tests/test_convolution.py
+++ b/scintillometry/tests/test_convolution.py
@@ -26,8 +26,8 @@ class TestConvolveDADA(UseDADASample):
         # Convolve everything.
         data1 = ct.read()
         assert ct.tell() == ct.shape[0] == fh.shape[0] - 2
-        assert abs(ct.start_time - fh.start_time -
-                   2 / fh.sample_rate) < 1. * u.ns
+        assert abs(ct.start_time - fh.start_time
+                   - 2 / fh.sample_rate) < 1. * u.ns
         assert abs(ct.stop_time - fh.stop_time) < 1. * u.ns
         assert np.allclose(expected, data1, atol=1.e-4)
 
@@ -59,8 +59,8 @@ class TestConvolveNoise:
     def test_offset(self, convolve_task, offset):
         # Have 16000 - 2 useful samples -> can use 842, but add 2 for response.
         ct = convolve_task(self.nh, self.response, offset=offset)
-        assert abs(ct.start_time - self.start_time -
-                   (2 - offset) / self.sample_rate) < 1. * u.ns
+        assert abs(ct.start_time - self.start_time
+                   - (2 - offset) / self.sample_rate) < 1. * u.ns
         expected = self.data[:-2] + self.data[1:-1] + self.data[2:]
         data1 = ct.read(10)
         assert np.allclose(data1, expected[:10])
@@ -73,10 +73,10 @@ class TestConvolveNoise:
     def test_different_response(self, convolve_task):
         response = np.array([[1., 1., 1.], [1., 1., 0.]]).T
         ct = convolve_task(self.nh, response, samples_per_frame=844)
-        assert abs(ct.start_time - self.start_time -
-                   2 / self.sample_rate) < 1. * u.ns
-        expected = (self.data[:-2] * np.array([1, 0]) + self.data[1:-1] +
-                    self.data[2:])
+        assert abs(ct.start_time
+                   - self.start_time - 2 / self.sample_rate) < 1. * u.ns
+        expected = (self.data[:-2] * np.array([1, 0]) + self.data[1:-1]
+                    + self.data[2:])
         data1 = ct.read()
         assert np.allclose(data1, expected[:data1.shape[0]])
 

--- a/scintillometry/tests/test_dispersion.py
+++ b/scintillometry/tests/test_dispersion.py
@@ -127,10 +127,10 @@ class TestDispersion:
         phase_delay = -2. * d * (1./(300. * u.MHz) -
                                  1./disperse.reference_frequency)
         # Sanity check of analytical derivation.
-        assert_quantity_allclose(- phase_delay - time_delay * 300 * u.MHz * u.cycle,
-                                 self.dm.phase_delay(300 * u.MHz,
-                                                     disperse.reference_frequency),
-                                 atol=0.001 * u.cycle)
+        assert_quantity_allclose(
+            - phase_delay - time_delay * 300 * u.MHz * u.cycle,
+            self.dm.phase_delay(300 * u.MHz, disperse.reference_frequency),
+            atol=0.001 * u.cycle)
 
         # Seek input time of the giant pulse, corrected to the reference
         # frequency, and read around it.
@@ -271,7 +271,8 @@ class TestDispersionRealDisjoint(TestDispersion):
         # pulse is zero.  But the total power there is small.
         assert np.all(p[:9] < 0.006)
         assert np.all(p[11:] < 0.006)
-        # Lower sideband [1] has lower frequencies and thus is dispersed to later.
+        # Lower sideband [1] has lower frequencies and thus is dispersed
+        # to later.
         assert p[9, 0] > 0.99 and p[10, 0] < 0.006
         assert p[10, 1] > 0.99 and p[9, 1] < 0.006
 

--- a/scintillometry/tests/test_dispersion.py
+++ b/scintillometry/tests/test_dispersion.py
@@ -40,8 +40,7 @@ class TestDispersion:
 
     def make_giant_pulse(self, sh):
         data = np.empty((sh.samples_per_frame,) + sh.shape[1:], sh.dtype)
-        do_gp = (sh.tell() + np.arange(sh.samples_per_frame) ==
-                 self.gp_sample)
+        do_gp = sh.tell() + np.arange(sh.samples_per_frame) == self.gp_sample
         data[...] = do_gp[:, np.newaxis]
         return data
 
@@ -60,8 +59,8 @@ class TestDispersion:
     def test_disperse_samples_per_frame(self, reference_frequency):
         disperse = Disperse(self.gp, self.dm,
                             reference_frequency=reference_frequency)
-        assert (disperse.samples_per_frame == 32768 - 6400 or
-                disperse.samples_per_frame == 32768 - 6401)
+        assert (disperse.samples_per_frame == 32768 - 6400
+                or disperse.samples_per_frame == 32768 - 6401)
 
     @pytest.mark.parametrize('reference_frequency', REFERENCE_FREQUENCIES)
     def test_disperse_time_offset(self, reference_frequency):
@@ -79,9 +78,9 @@ class TestDispersion:
                             reference_frequency=reference_frequency)
         # Seek input time of the giant pulse, corrected to the reference
         # frequency, and read around it.
-        t_gp = (self.start_time + self.gp_sample / self.sample_rate +
-                self.dm.time_delay(300. * u.MHz,
-                                   disperse.reference_frequency))
+        t_gp = (self.start_time + self.gp_sample / self.sample_rate
+                + self.dm.time_delay(300. * u.MHz,
+                                     disperse.reference_frequency))
         disperse.seek(t_gp)
         disperse.seek(-self.gp_sample // 2, 1)
         around_gp = disperse.read(self.gp_sample)
@@ -124,8 +123,8 @@ class TestDispersion:
         # phase_delay(freq, 300MHz) - phase_delay(freq, reference_frequency)
         # This yields a time shift as well as a phase shift given by:
         d = self.dm.dispersion_delay_constant * self.dm * u.cycle
-        phase_delay = -2. * d * (1./(300. * u.MHz) -
-                                 1./disperse.reference_frequency)
+        phase_delay = -2. * d * (1./(300. * u.MHz)
+                                 - 1./disperse.reference_frequency)
         # Sanity check of analytical derivation.
         assert_quantity_allclose(
             - phase_delay - time_delay * 300 * u.MHz * u.cycle,
@@ -134,8 +133,8 @@ class TestDispersion:
 
         # Seek input time of the giant pulse, corrected to the reference
         # frequency, and read around it.
-        t_gp = (self.start_time + self.gp_sample / self.sample_rate +
-                time_delay)
+        t_gp = (self.start_time + self.gp_sample / self.sample_rate
+                + time_delay)
         # Dedisperse to mean frequency = 300 MHz, and read dedispersed pulse.
         dedisperse = Dedisperse(disperse, self.dm)
         dedisperse.seek(t_gp)
@@ -220,8 +219,8 @@ class TestDispersionReal(TestDispersion):
     def test_disperse_samples_per_frame(self, reference_frequency):
         disperse = Disperse(self.gp, self.dm,
                             reference_frequency=reference_frequency)
-        assert (disperse.samples_per_frame == 65536 - 12800 or
-                disperse.samples_per_frame == 65536 - 12801)
+        assert (disperse.samples_per_frame == 65536 - 12800
+                or disperse.samples_per_frame == 65536 - 12801)
 
 
 class TestDispersionRealDisjoint(TestDispersion):
@@ -244,8 +243,7 @@ class TestDispersionRealDisjoint(TestDispersion):
 
     def make_giant_pulse(self, sh):
         data = np.empty((sh.samples_per_frame,) + sh.shape[1:], sh.dtype)
-        do_gp = (sh.tell() + np.arange(sh.samples_per_frame) ==
-                 self.gp_sample)
+        do_gp = sh.tell() + np.arange(sh.samples_per_frame) == self.gp_sample
         data[...] = do_gp[:, np.newaxis]
         return data
 

--- a/scintillometry/tests/test_dm.py
+++ b/scintillometry/tests/test_dm.py
@@ -46,20 +46,20 @@ class TestDM:
         ref_freq = 321.582761 * u.MHz
         dm = DispersionMeasure(self.dm_val)
 
-        time_delay = (dm.dispersion_delay_constant * dm *
-                      (1. / freqs**2 - 1. / ref_freq**2))
+        time_delay = (dm.dispersion_delay_constant * dm
+                      * (1. / freqs**2 - 1. / ref_freq**2))
         assert_quantity_allclose(dm.time_delay(freqs, ref_freq),
                                  time_delay, rtol=1e-13)
         time_delay_infref = dm.dispersion_delay_constant * dm / freqs**2
         assert_quantity_allclose(dm.time_delay(freqs),
                                  time_delay_infref, rtol=1e-13)
 
-        phase_delay = (2. * np.pi * u.rad * dm.dispersion_delay_constant * dm *
-                       freqs * (1. / ref_freq - 1. / freqs)**2)
+        phase_delay = (2. * np.pi * u.rad * dm.dispersion_delay_constant * dm
+                       * freqs * (1. / ref_freq - 1. / freqs)**2)
         assert_quantity_allclose(dm.phase_delay(freqs, ref_freq),
                                  phase_delay, rtol=1e-13)
-        phase_delay_infref = (2. * np.pi * u.rad *
-                              dm.dispersion_delay_constant * dm * 1. / freqs)
+        phase_delay_infref = (2. * np.pi * u.rad
+                              * dm.dispersion_delay_constant * dm * 1. / freqs)
         assert_quantity_allclose(dm.phase_delay(freqs),
                                  phase_delay_infref, rtol=1e-13)
 

--- a/scintillometry/tests/test_functions.py
+++ b/scintillometry/tests/test_functions.py
@@ -27,8 +27,8 @@ class TestSquareComplex(UseDADASample):
         # Square everything.
         data1 = st.read()
         assert st.tell() == st.shape[0]
-        assert (st.time - st.start_time -
-                st.shape[0] / st.sample_rate) < 1*u.ns
+        assert abs(st.time
+                   - st.start_time - st.shape[0] / st.sample_rate) < 1*u.ns
         assert st.dtype is ref_data.dtype is data1.dtype
         assert np.allclose(ref_data, data1)
 
@@ -85,8 +85,8 @@ class TestPoweDADAr(UseDADASample):
 
         # Square everything.
         data1 = pt.read()
-        assert (pt.time - fh.start_time -
-                fh.shape[0] / fh.sample_rate) < 1*u.ns
+        assert abs(pt.time
+                   - fh.start_time - fh.shape[0] / fh.sample_rate) < 1*u.ns
         assert pt.dtype is ref_data.dtype is data1.dtype
         assert np.allclose(ref_data, data1)
         pt.close()

--- a/scintillometry/tests/test_functions.py
+++ b/scintillometry/tests/test_functions.py
@@ -9,7 +9,6 @@ from astropy.time import Time
 from ..base import SetAttribute
 from ..functions import Square, Power
 from ..generators import EmptyStreamGenerator
-from ..shaping import Reshape
 
 from .common import UseDADASample, UseVDIFSample
 

--- a/scintillometry/tests/test_generators.py
+++ b/scintillometry/tests/test_generators.py
@@ -94,6 +94,7 @@ class TestGenerator(StreamBase):
 
 class TestConstant(StreamBase):
     """Test sources that produce constant signals."""
+
     def test_zeros_generation(self):
         def generate_zero(sh):
             return np.zeros((sh.samples_per_frame,) + sh.shape[1:],
@@ -205,6 +206,7 @@ class TestNoise:
 
     And that the noise generator looks like a streamreader.
     """
+
     def setup(self):
         self.seed = 1234567
         self.start_time = Time('2010-11-12T13:14:15')

--- a/scintillometry/tests/test_generators.py
+++ b/scintillometry/tests/test_generators.py
@@ -28,10 +28,12 @@ class TestGenerator(StreamBase):
     def test_basics(self):
         with StreamGenerator(self.my_source,
                              shape=self.shape, start_time=self.start_time,
-                             sample_rate=self.sample_rate, samples_per_frame=1) as sh:
+                             sample_rate=self.sample_rate,
+                             samples_per_frame=1) as sh:
             assert sh.size == np.prod(self.shape)
             assert sh.shape == self.shape
-            assert isinstance(sh.dtype, np.dtype) and sh.dtype == np.dtype('c8')
+            assert isinstance(sh.dtype, np.dtype)
+            assert sh.dtype == np.dtype('c8')
             assert sh.samples_per_frame == 1
             assert abs(sh.stop_time - sh.start_time - 1. * u.s) < 1. * u.ns
             sh.seek(980)
@@ -48,7 +50,8 @@ class TestGenerator(StreamBase):
         with StreamGenerator(self.my_source,
                              frequency=frequency, sideband=sideband,
                              shape=self.shape, start_time=self.start_time,
-                             sample_rate=self.sample_rate, samples_per_frame=1) as sh:
+                             sample_rate=self.sample_rate,
+                             samples_per_frame=1) as sh:
             assert np.all(sh.frequency == frequency)
             assert np.all(sh.sideband == sideband)
             with pytest.raises(AttributeError):
@@ -61,7 +64,8 @@ class TestGenerator(StreamBase):
         with StreamGenerator(self.my_source, polarization=polarization,
                              frequency=frequency, sideband=sideband,
                              shape=self.shape, start_time=self.start_time,
-                             sample_rate=self.sample_rate, samples_per_frame=1) as sh:
+                             sample_rate=self.sample_rate,
+                             samples_per_frame=1) as sh:
             assert np.all(sh.frequency == frequency)
             assert np.all(sh.sideband == sideband)
             assert np.all(sh.polarization == polarization)
@@ -69,7 +73,8 @@ class TestGenerator(StreamBase):
     def test_exceptions(self):
         with StreamGenerator(self.my_source,
                              shape=self.shape, start_time=self.start_time,
-                             sample_rate=self.sample_rate, samples_per_frame=1) as sh:
+                             sample_rate=self.sample_rate,
+                             samples_per_frame=1) as sh:
             with pytest.raises(EOFError):
                 sh.seek(-10, 2)
                 sh.read(20)

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -89,7 +89,8 @@ class TestIntegrate(TestFakePulsarBase):
         ip = Integrate(st, average=False)
         assert ip.start_time == self.sh.start_time
         assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
+        assert abs(ip.stop_time - self.sh.start_time -
+                   1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         integrated = ip.read()
@@ -193,7 +194,8 @@ class TestIntegrate(TestFakePulsarBase):
         expected_count = [2, 3, 2, 2, 2, 3, 2, 2]
         step = 2.26 / self.sample_rate
         raw = self.raw_power[:18]
-        ref_data = np.add.reduceat(raw, np.add.accumulate([0] + expected_count[:-1]))
+        ref_data = np.add.reduceat(
+            raw, np.add.accumulate([0] + expected_count[:-1]))
 
         st = Square(self.sh)
         ip = Integrate(st, step, average=False,

--- a/scintillometry/tests/test_integration.py
+++ b/scintillometry/tests/test_integration.py
@@ -57,8 +57,8 @@ class TestIntegrate(TestFakePulsarBase):
         ip = Integrate(st)
         assert ip.start_time == self.sh.start_time
         assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - self.sh.start_time -
-                   1./ip.sample_rate) < 1. * u.ns
+        assert abs(ip.stop_time
+                   - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         data = ip.read()
@@ -73,8 +73,8 @@ class TestIntegrate(TestFakePulsarBase):
 
         st = Square(self.sh)
         ip = Integrate(st, start=151)
-        assert abs(ip.start_time - (self.sh.start_time +
-                                    151 / self.sh.sample_rate)) < 1. * u.ns
+        assert abs(ip.start_time - (self.sh.start_time
+                                    + 151 / self.sh.sample_rate)) < 1. * u.ns
         assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
 
         # Square and integrate everything.
@@ -89,8 +89,8 @@ class TestIntegrate(TestFakePulsarBase):
         ip = Integrate(st, average=False)
         assert ip.start_time == self.sh.start_time
         assert abs(ip.stop_time - self.sh.stop_time) < 1. * u.ns
-        assert abs(ip.stop_time - self.sh.start_time -
-                   1./ip.sample_rate) < 1. * u.ns
+        assert abs(ip.stop_time
+                   - self.sh.start_time - 1./ip.sample_rate) < 1. * u.ns
 
         # Square and integrate everything.
         integrated = ip.read()
@@ -132,8 +132,8 @@ class TestIntegrate(TestFakePulsarBase):
         st = Square(self.sh)
         ip = Integrate(st, n/self.sh.sample_rate, start=121*n, average=False,
                        samples_per_frame=samples_per_frame)
-        assert abs(ip.start_time - (self.sh.start_time +
-                                    121 * n / self.sh.sample_rate)) < 1. * u.ns
+        assert abs(ip.start_time - (self.sh.start_time
+                                    + 121 * n / self.sh.sample_rate)) < 1.*u.ns
         assert ip.sample_rate == self.sh.sample_rate / n
 
         integrated = ip.read(10)
@@ -291,8 +291,8 @@ class TestFold(TestFakePulsarBase):
         assert np.all(fr_count.sum(1) == 300)
 
         # Test the output on and off gates.  3 gates -> 7.5 bins.
-        pulse_power = (fr_data[:, (0, 1, -1)].sum(1) /
-                       fr_count[:, (0, 1, -1)].sum(1))
+        pulse_power = (fr_data[:, (0, 1, -1)].sum(1)
+                       / fr_count[:, (0, 1, -1)].sum(1))
         assert np.all(np.abs(pulse_power - 10. / 7.5 - 0.125) < 0.5), \
             "On-gate power is incorrect."
 
@@ -334,8 +334,8 @@ class TestFold(TestFakePulsarBase):
 
     def test_read_whole_file(self):
         ref_data = self.raw_data[:, 0]
-        phase = self.phase(self.start_time +
-                           np.arange(self.shape[0]) / self.sample_rate)
+        phase = self.phase(self.start_time
+                           + np.arange(self.shape[0]) / self.sample_rate)
         i_phase = ((phase.to_value(u.cycle) * self.n_phase) %
                    self.n_phase).astype(int)
         expected = np.bincount(i_phase, ref_data) / np.bincount(i_phase)
@@ -350,10 +350,10 @@ class TestFold(TestFakePulsarBase):
     def test_read_part(self):
         ref_data = self.raw_data[10000:, 0]
         start = self.start_time + 10000 / self.sample_rate
-        phase = self.phase(start + np.arange(self.shape[0] - 10000) /
-                           self.sample_rate)
-        i_phase = ((phase.to_value(u.cycle) *
-                    self.n_phase) % self.n_phase).astype(int)
+        phase = self.phase(start + (np.arange(self.shape[0] - 10000)
+                                    / self.sample_rate))
+        i_phase = ((phase.to_value(u.cycle) * self.n_phase)
+                   % self.n_phase).astype(int)
         expected = np.bincount(i_phase, ref_data) / np.bincount(i_phase)
 
         fh = Fold(self.sh, self.n_phase, self.phase, average=False,
@@ -434,10 +434,10 @@ class TestStack(TestFakePulsarBase):
         ref_data = self.raw_data[124:-1].reshape(-1, 25, 5, 2).mean(2)
 
         fh = Stack(self.sh, 25, self.phase, start=124)
-        assert abs(fh.start_time - self.start_time -
-                   124 / self.sample_rate) < 1. * u.ns
-        assert abs(fh.stop_time -
-                   (self.sh.stop_time - 1 / self.sample_rate)) < 1. * u.ns
+        assert abs(fh.start_time
+                   - self.start_time - 124 / self.sample_rate) < 1. * u.ns
+        assert abs(fh.stop_time
+                   - (self.sh.stop_time - 1 / self.sample_rate)) < 1. * u.ns
         assert fh.sample_rate == 1. / u.cycle
 
         data = fh.read(2)

--- a/scintillometry/tests/test_io_psrfits_read.py
+++ b/scintillometry/tests/test_io_psrfits_read.py
@@ -71,14 +71,13 @@ class TestFoldRead(TestRead):
         mjdi = int(start_time0.mjd)
         mjdf = start_time0 - Time(mjdi, 0.0, format='mjd')
         sec_frac, sec_int = np.modf(mjdf.to(u.s).value)
-        assert np.isclose(self.reader.ih.primary_hdu.header['STT_IMJD'], mjdi), \
-            "The header HDU start time's integer MJD is not reading correctly."
-        assert np.isclose(self.reader.ih.primary_hdu.header['STT_SMJD'], sec_int), \
-            ("The header HDU start time's integer second is not reading"
-             "correctly.")
-        assert np.isclose(self.reader.ih.primary_hdu.header['STT_OFFS'], sec_frac), \
-            ("The header HDU start time's fractional second is not reading"
-             "correctly.")
+        assert self.reader.ih.primary_hdu.header['STT_IMJD'] == mjdi, \
+            "HDU start time's integer MJD is not reading correctly."
+        assert self.reader.ih.primary_hdu.header['STT_SMJD'] == sec_int, \
+            "HDU start time's integer second is not reading correctly."
+        assert np.isclose(self.reader.ih.primary_hdu.header['STT_OFFS'],
+                          sec_frac), \
+            "HDU start time's fractional second is not reading correctly."
         # Subint start time
         start_time1 = self.reader.start_time
         psrchive_time = self.psrchive_res['t'][0]

--- a/scintillometry/tests/test_io_psrfits_read.py
+++ b/scintillometry/tests/test_io_psrfits_read.py
@@ -103,8 +103,8 @@ class TestFoldRead(TestRead):
 
         # Test against psrchive result
         psrdata = self.psrchive_res['data']
-        assert psrdata.shape == ((self.reader.shape[0],) +
-                                 self.reader.sample_shape[::-1]), \
+        assert psrdata.shape == ((self.reader.shape[0],)
+                                 + self.reader.sample_shape[::-1]), \
             "Data shape is not the same with PSRCHIVE result"
         psrdata = psrdata.reshape(shape1)
         assert np.all(np.isclose(psrdata, fold_data)), \

--- a/scintillometry/tests/test_io_psrfits_setter.py
+++ b/scintillometry/tests/test_io_psrfits_setter.py
@@ -34,8 +34,8 @@ class TestWriter:
 
     def test_set_telescope(self):
         self.p_hdu.telescope = self.input_p_hdu.telescope
-        assert (self.p_hdu.header['TELESCOP'] ==
-                self.input_p_hdu.header['TELESCOP'])
+        assert (self.p_hdu.header['TELESCOP']
+                == self.input_p_hdu.header['TELESCOP'])
 
     def test_set_start_time(self):
         self.p_hdu.start_time = self.input_p_hdu.start_time
@@ -50,12 +50,12 @@ class TestWriter:
 
     def test_set_freq(self):
         self.p_hdu.frequency = self.input_p_hdu.frequency
-        assert (self.p_hdu.header['OBSNCHAN'] ==
-                self.input_p_hdu.header['OBSNCHAN'])
-        assert (self.p_hdu.header['OBSFREQ'] ==
-                self.input_p_hdu.header['OBSFREQ'])
-        assert (self.p_hdu.header['OBSBW'] ==
-                self.input_p_hdu.header['OBSBW'])
+        assert (self.p_hdu.header['OBSNCHAN']
+                == self.input_p_hdu.header['OBSNCHAN'])
+        assert (self.p_hdu.header['OBSFREQ']
+                == self.input_p_hdu.header['OBSFREQ'])
+        assert (self.p_hdu.header['OBSBW']
+                == self.input_p_hdu.header['OBSBW'])
 
     def test_set_sideband(self):
         self.p_hdu.header['OBSBW'] = self.input_p_hdu.header['OBSBW']
@@ -63,8 +63,8 @@ class TestWriter:
         assert (self.p_hdu.header['OBSBW'] ==
                 -self.input_p_hdu.header['OBSBW'])
         self.p_hdu.sideband = self.input_p_hdu.sideband
-        assert (self.p_hdu.header['OBSBW'] ==
-                self.input_p_hdu.header['OBSBW'])
+        assert (self.p_hdu.header['OBSBW']
+                == self.input_p_hdu.header['OBSBW'])
 
     def test_set_mode(self):
         self.p_hdu.obs_mode = 'PSR'
@@ -75,10 +75,10 @@ class TestWriter:
     def test_set_skycoord(self):
         self.p_hdu.ra = self.input_p_hdu.ra
         self.p_hdu.dec = self.input_p_hdu.dec
-        assert (Longitude(self.p_hdu.header['RA'], unit=u.hourangle) ==
-                Longitude(self.input_p_hdu.header['RA'], unit=u.hourangle))
-        assert (Latitude(self.p_hdu.header['DEC'], unit=u.deg) ==
-                Latitude(self.input_p_hdu.header['DEC'], unit=u.deg))
+        assert (Longitude(self.p_hdu.header['RA'], unit=u.hourangle)
+                == Longitude(self.input_p_hdu.header['RA'], unit=u.hourangle))
+        assert (Latitude(self.p_hdu.header['DEC'], unit=u.deg)
+                == Latitude(self.input_p_hdu.header['DEC'], unit=u.deg))
 
 
 class TestPSRHDUWriter(TestWriter):
@@ -128,8 +128,8 @@ class TestPSRHDUWriter(TestWriter):
 
     def test_set_start_time(self):
         self.psr_hdu.start_time = self.reader.start_time
-        assert np.abs(self.psr_hdu.start_time -
-                      self.reader.start_time) < 1 * u.ns
+        assert np.abs(self.psr_hdu.start_time
+                      - self.reader.start_time) < 1 * u.ns
 
     def test_set_frequency(self):
         self.psr_hdu.frequency = self.reader.frequency
@@ -141,9 +141,9 @@ class TestPSRHDUWriter(TestWriter):
         test_fits = str(tmpdir.join('test_column_writing.fits'))
         test_data = self.reader.read(1)
         # PSRFITS rounds, not truncates data.
-        in_data = np.around(((test_data - self.reader.ih.data['DAT_OFFS']) /
-                            self.reader.ih.data['DAT_SCL'])).reshape(
-                                self.psr_hdu.data['DATA'].shape)
+        in_data = np.around(((test_data - self.reader.ih.data['DAT_OFFS'])
+                             / self.reader.ih.data['DAT_SCL'])).reshape(
+            self.psr_hdu.data['DATA'].shape)
         self.psr_hdu.data['DATA'] = in_data
         self.psr_hdu.data['DAT_SCL'] = self.reader.ih.data['DAT_SCL']
         self.psr_hdu.data['DAT_OFFS'] = self.reader.ih.data['DAT_OFFS']
@@ -157,8 +157,8 @@ class TestPSRHDUWriter(TestWriter):
         with psrfits.open(test_fits, weighted=False) as column_reader:
             assert np.array_equal(self.reader.ih.data['DATA'],
                                   column_reader.ih.data['DATA'])
-            assert np.abs(column_reader.start_time -
-                          self.reader.start_time) < 1 * u.ns
+            assert np.abs(column_reader.start_time
+                          - self.reader.start_time) < 1 * u.ns
             assert u.isclose(column_reader.sample_rate,
                              self.reader.sample_rate)
             # And read from it, checking the output is the same as well.

--- a/scintillometry/tests/test_phase_class.py
+++ b/scintillometry/tests/test_phase_class.py
@@ -111,8 +111,8 @@ class PhaseSetup:
     def setup(self):
         self.phase1 = Angle(np.array([1000., 1001., 999., 1005, 1006.]),
                             u.cycle)[:, np.newaxis]
-        self.phase2 = Angle(2.**(-53) * np.array([1, -1., 1., -1.]) +
-                            np.array([-0.5, 0., 0., 0.5]), u.cycle)
+        self.phase2 = Angle(2.**(-53) * np.array([1, -1., 1., -1.])
+                            + np.array([-0.5, 0., 0., 0.5]), u.cycle)
         self.phase = Phase(self.phase1, self.phase2)
         self.delta = Phase(0., self.phase2)
         self.im_phase = Phase(self.phase1 * 1j, self.phase2 * 1j)
@@ -682,6 +682,7 @@ class TestPhaseString(PhaseSetup):
 
 class TestFractionalPhase(PhaseSetup):
     """Since FractionalPhase is a subclass of Longitude, only limited tests."""
+
     def test_keep_precision(self):
         fp = FractionalPhase(self.phase)
         assert np.all(fp == self.phase2)

--- a/scintillometry/tests/test_phase_class.py
+++ b/scintillometry/tests/test_phase_class.py
@@ -7,7 +7,6 @@ import pytest
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle
-from astropy.time import Time
 
 from ..phases import Phase, FractionalPhase
 

--- a/scintillometry/tests/test_phases.py
+++ b/scintillometry/tests/test_phases.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 from ..phases import PolycoPhase, PintPhase, Phase
 
 try:
-    import pint
+    import pint  # noqa
     HAS_PINT = True
 except ImportError:
     HAS_PINT = False
@@ -20,8 +20,9 @@ else:
     # "stropy.extern.six will be removed in 4.0").
     # It also has warnings itself from "log.warn" that we cannot avoid.
     # TODO: remove once PINT has been updated.
-    pytestmark = [pytest.mark.filterwarnings("ignore:::astropy"),
-                  pytest.mark.filterwarnings("ignore::DeprecationWarning:pint")]
+    pytestmark = [
+        pytest.mark.filterwarnings("ignore:::astropy"),
+        pytest.mark.filterwarnings("ignore::DeprecationWarning:pint")]
 
 
 test_data = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/scintillometry/tests/test_sampling.py
+++ b/scintillometry/tests/test_sampling.py
@@ -27,8 +27,8 @@ class TestResampleReal:
         f_sine = self.sample_rate / 32
 
         def cosine(handle):
-            dt = (handle.offset +
-                  np.arange(handle.samples_per_frame)) / handle.sample_rate
+            dt = (handle.offset
+                  + np.arange(handle.samples_per_frame)) / handle.sample_rate
             phi = (f_sine * dt * u.cycle).to_value(u.rad)
             if handle.dtype.kind == 'f':
                 cosine = np.sin(phi)
@@ -64,22 +64,22 @@ class TestResampleReal:
     def test_resample(self, offset):
         ih = Resample(self.part_fh, offset, samples_per_frame=512)
         # Always lose 1 sample per frame.
-        assert ih.shape == ((self.part_fh.shape[0] - 1,) +
-                            self.part_fh.sample_shape)
+        assert ih.shape == ((self.part_fh.shape[0] - 1,)
+                            + self.part_fh.sample_shape)
         # Check we are at the given offset.
         if isinstance(offset, Time):
             expected_time = offset
         elif isinstance(offset, u.Quantity):
             expected_time = self.part_fh.start_time + offset
         else:
-            expected_time = (self.part_fh.start_time +
-                             offset / self.part_fh.sample_rate)
+            expected_time = (self.part_fh.start_time
+                             + offset / self.part_fh.sample_rate)
         assert abs(ih.time - expected_time) < 1. * u.ns
 
         ioffset, fraction = divmod(float_offset(self.part_fh, offset), 1)
         assert ih.offset == ioffset
-        expected_start_time = (self.part_fh.start_time +
-                               fraction / self.part_fh.sample_rate)
+        expected_start_time = (self.part_fh.start_time
+                               + fraction / self.part_fh.sample_rate)
         assert abs(ih.start_time - expected_start_time) < 1. * u.ns
         ih.seek(0)
         data = ih.read()

--- a/scintillometry/tests/test_sampling.py
+++ b/scintillometry/tests/test_sampling.py
@@ -64,7 +64,8 @@ class TestResampleReal:
     def test_resample(self, offset):
         ih = Resample(self.part_fh, offset, samples_per_frame=512)
         # Always lose 1 sample per frame.
-        assert ih.shape == (self.part_fh.shape[0] - 1,) + self.part_fh.sample_shape
+        assert ih.shape == ((self.part_fh.shape[0] - 1,) +
+                            self.part_fh.sample_shape)
         # Check we are at the given offset.
         if isinstance(offset, Time):
             expected_time = offset
@@ -107,7 +108,8 @@ class TestResampleNoise(TestResampleComplex):
 
     def setup(self):
         # Make noise with only frequencies covered by part.
-        part_ft_noise = np.random.normal(size=512*2*2).view('c16').reshape(-1, 2)
+        part_ft_noise = (np.random.normal(size=512*2*2)
+                         .view('c16').reshape(-1, 2))
         # Make corresponding FT for full frame.
         full_ft_noise = np.concatenate((part_ft_noise[:256],
                                         np.zeros((512*3, 2), 'c16'),

--- a/scintillometry/tests/test_shaping.py
+++ b/scintillometry/tests/test_shaping.py
@@ -84,8 +84,8 @@ class TestTranspose(UseVDIFSampleWithAttrs):
         assert tt.sideband.shape == ()
         assert np.all(tt.sideband == 1)
         assert tt.polarization.shape == (2, 1)
-        assert np.all(tt.polarization ==
-                      self.fh.polarization[:2].reshape(2, 1))
+        assert np.all(tt.polarization
+                      == self.fh.polarization[:2].reshape(2, 1))
 
     def test_frequency_sideband_polarization_propagation2(self):
         # Add different frequency, sideband, and polarization information.

--- a/scintillometry/tests/test_shaping.py
+++ b/scintillometry/tests/test_shaping.py
@@ -84,7 +84,8 @@ class TestTranspose(UseVDIFSampleWithAttrs):
         assert tt.sideband.shape == ()
         assert np.all(tt.sideband == 1)
         assert tt.polarization.shape == (2, 1)
-        assert np.all(tt.polarization == self.fh.polarization[:2].reshape(2, 1))
+        assert np.all(tt.polarization ==
+                      self.fh.polarization[:2].reshape(2, 1))
 
     def test_frequency_sideband_polarization_propagation2(self):
         # Add different frequency, sideband, and polarization information.

--- a/scintillometry/tests/test_simulate.py
+++ b/scintillometry/tests/test_simulate.py
@@ -1,7 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE
 """Full-package tests of simulating sources."""
 
-import pytest
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
@@ -83,7 +82,7 @@ class TestCyclicModulation(NoiseStreamBase):
         return (t * 3. * u.Hz).to(1).value
 
     def gaussian_profile(self, phase):
-        """Gaussian profile at 0.5 w/ width=0.05; base of 1., amplitude 0.125."""
+        """Gaussian at 0.5 w/ width=0.05; base of 1., amplitude 0.125."""
         return 1. + 0.125 * np.exp(-((phase - 0.5) / 0.05)**2)
 
     def profile(self, fh, data):

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,11 +51,12 @@ auto_use = True
 ignore=
     # missing whitespace around arithmetic operator
     E226,
-    # line break after binary operator (have to choose before or after),
-    W504
+    # line break before binary operator (have to choose before or after),
+    W503
 exclude =
     # part of astropy affilliated package template, not our worry.
     scintillometry/conftest.py,scintillometry/version.py,scintillometry/__init__.py,
+    scintillometry/_astropy_init.py,
     docs/conf.py,
     ah_bootstrap.py,setup.py,ez_setup.py,
     astropy_helpers,
@@ -66,6 +67,7 @@ exclude =
 exclude =
     # part of astropy affilliated package template, not our worry.
     scintillometry/conftest.py,scintillometry/version.py,scintillometry/__init__.py,
+    scintillometry/_astropy_init.py,
     docs/conf.py,
     ah_bootstrap.py,setup.py,ez_setup.py,
     astropy_helpers,

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,6 @@ auto_use = True
 ignore=
     # missing whitespace around arithmetic operator
     E226,
-    # line too long
-    E501,
-    # unused import, import * (for __init__.py)
-    F401, F403,
     # line break after binary operator (have to choose before or after),
     W504
 exclude =


### PR DESCRIPTION
We had exceptions for `flake8` in `setup.cfg`, which were picked up at least by my emacs, leading me to miss the substantial number of warnings. These are all fixed here, with the exceptions being moved to the travis setup (since we don't necessarily want to fail a PR just because one line is too long).