### PR TITLE
Allow half-float storage in HDF5 files, also for complex numbers

### DIFF
--- a/docs/io/hdf5/index.rst
+++ b/docs/io/hdf5/index.rst
@@ -33,6 +33,11 @@ For instance::
   >>> (squared == recovered).all()
   True
 
+It is also possible to stored data encoding using the standard
+``vdif`` schemes by passing in ``bps`` and ``complex_data``.
+Alternatively, half-precision floats can be used by passing in
+``encoded_dtype='f2'`` or ``'c4'``.
+
 .. _hdf5_api:
 
 Reference/API

--- a/scintillometry/io/hdf5/base.py
+++ b/scintillometry/io/hdf5/base.py
@@ -191,6 +191,11 @@ def open(filename, mode='r', **kwargs):
     dtype : str or `~numpy.dtype`
         Data type of the raw data.  Should only be given if ``bps`` and
         ``complex_data`` are not given.
+    encoded_dtype : str or `~numpy.dtype`, optional
+        Data type of the encoded data.  By default, equal to ``dtype``, but
+        can be used to reduce the precision, e.g., to half-precision with
+        'f2' for real-valued data or the custom 'c4' dtype for complex.
+        Should only be given if ``bps`` and ``complex_data`` are not given.
     complex_data : bool, optional
         Whether encoded data are complex (default: `False`).  Should only
         be given if ``dtype`` is not given.

--- a/scintillometry/io/hdf5/tests/test_hdf5.py
+++ b/scintillometry/io/hdf5/tests/test_hdf5.py
@@ -1,6 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE
 """Tests of the HDF5 reader/writer."""
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 from astropy import units as u
 from astropy.time import Time
@@ -31,17 +32,32 @@ class TestHDF5Basics:
     def test_create_raw_header(self):
         header = hdf5.HDF5Header(dtype='c8', **self.info)
         assert set(header.keys()) == set(self.info.keys()) | {'dtype'}
-        assert dict(header) == dict(dtype='c8', **self.info)
+        assert dict(header) == dict(dtype='complex64', **self.info)
         assert all(getattr(header, key) == self.info[key]
                    for key in self.info.keys())
         assert isinstance(header['dtype'], str)
-        assert header['dtype'] == 'c8'
         assert isinstance(header.dtype, np.dtype)
         assert header.dtype == 'c8'
         assert not hasattr(header, 'bps')
         assert not hasattr(header, 'complex_data')
         with pytest.raises(KeyError, match='dtype'):
             hdf5.HDF5Header(**self.info)
+
+    def test_create_c4_header(self):
+        header = hdf5.HDF5Header(encoded_dtype='c4', **self.info)
+        assert set(header.keys()) == (set(self.info.keys())
+                                      | {'encoded_dtype', 'dtype'})
+        assert dict(header) == dict(encoded_dtype='<c4', dtype='complex64',
+                                    **self.info)
+        assert all(getattr(header, key) == self.info[key]
+                   for key in self.info.keys())
+        assert header.encoded_dtype == hdf5.payload.DTYPE_C4
+        assert header.dtype == 'c8'
+        with pytest.raises(AssertionError):
+            hdf5.HDF5Header(encoded_dtype='c4', complex_data=False,
+                            **self.info)
+        with pytest.raises(TypeError):
+            hdf5.HDF5Header(encoded_dtype='c2', **self.info)
 
     def test_create_coded_header(self):
         header = hdf5.HDF5Header(bps=2, complex_data=False, **self.info)
@@ -52,9 +68,46 @@ class TestHDF5Basics:
                    for key in self.info.keys())
         assert header.bps == 2
         assert header.complex_data is False
+        assert header.encoded_dtype == '<u4'
         assert not hasattr(header, 'dtype')
         with pytest.raises(KeyError, match='complex_data'):
             hdf5.HDF5Header(bps=2, **self.info)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_create_raw_payload(self, tmpdir):
+        header = hdf5.HDF5Header(dtype='c8', **self.info)
+        filename = str(tmpdir.join('trial.hdf5'))
+        with h5py.File(filename, 'w') as h5:
+            payload = hdf5.HDF5Payload.fromfile(h5, header)
+            assert payload.dtype == 'c8'
+            assert payload.shape == ((header.samples_per_frame,)
+                                     + header.sample_shape)
+            assert payload.words.dtype == 'c8'
+            assert payload.words.shape == payload.shape
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_create_c4_payload(self, tmpdir):
+        header = hdf5.HDF5Header(encoded_dtype='c4', **self.info)
+        filename = str(tmpdir.join('trial.hdf5'))
+        with h5py.File(filename, 'w') as h5:
+            payload = hdf5.HDF5Payload.fromfile(h5, header)
+            assert payload.dtype == 'c8'
+            assert payload.shape == ((header.samples_per_frame,)
+                                     + header.sample_shape)
+            assert payload.words.dtype == hdf5.payload.DTYPE_C4
+            assert payload.words.shape == payload.shape
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_create_coded_payload(self, tmpdir):
+        header = hdf5.HDF5Header(bps=2, complex_data=False, **self.info)
+        filename = str(tmpdir.join('trial.hdf5'))
+        with h5py.File(filename, 'w') as h5:
+            payload = hdf5.HDF5Payload.fromfile(h5, header)
+            assert payload.dtype == 'f4'
+            assert payload.shape == ((header.samples_per_frame,)
+                                     + header.sample_shape)
+            assert payload.words.dtype == '<u4'
+            assert payload.words.shape == (100 * 16 * 2 // 32,)
 
 
 class TestHDF5:
@@ -91,7 +144,10 @@ class TestHDF5:
             stream_attr = getattr(stream, (attr if attr != 'time'
                                            else 'start_time'))
             header_attr = getattr(header, attr)
-            assert np.all(header_attr == stream_attr)
+            if attr == 'time':
+                assert np.all(np.abs(header_attr - stream_attr) < 1.*u.ns)
+            else:
+                assert np.all(header_attr == stream_attr)
             if is_header:
                 if attr in exclude:
                     assert attr not in header
@@ -156,14 +212,14 @@ class TestHDF5:
             self.check(stream, header)
             assert header == header0
             payload = hdf5.HDF5Payload.fromfile(h5, header)
-            assert np.all(payload.data == self.data)
-            assert np.all(payload[:] == self.data)
+            assert_array_equal(payload.data, self.data)
+            assert_array_equal(payload[:], self.data)
 
         with hdf5.open(filename, 'r') as f5r:
             self.check(stream, f5r)
             assert f5r.header0 == header0
             data = f5r.read()
-            assert np.all(data == self.data)
+            assert_array_equal(data, self.data)
             # Check repr works, though ignore the contents for now.
             repr(f5r)
 
@@ -205,4 +261,108 @@ class TestHDF5:
         with hdf5.open(filename, 'r') as f5r:
             self.check(stream, f5r)
             data = f5r.read()
-            assert np.all(data == self.data)
+            assert_array_equal(data, self.data)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_stream_as_f2(self, tmpdir):
+        stream = self.wrapped
+        filename = str(tmpdir.join('copy.hdf5'))
+        with hdf5.open(filename, 'w', template=stream,
+                       encoded_dtype='f2') as f5w:
+            assert f5w.header0.encoded_dtype == '<f2'
+            assert f5w.header0.dtype == '=f4'
+            assert not f5w.complex_data
+            stream.seek(0)
+            stream.read(out=f5w)
+
+        with hdf5.open(filename, 'r') as f5r:
+            self.check(f5w, f5r)
+            assert f5r.header0.encoded_dtype == '<f2'
+            assert f5r.dtype == '=f4'
+            data = f5r.read()
+            assert np.allclose(data, self.data, atol=0,
+                               rtol=np.finfo('f2').eps)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_complex_baseband(self, tmpdir):
+        filename = str(tmpdir.join('copy.hdf5'))
+        with baseband.vdif.open(baseband.data.SAMPLE_AROCHIME_VDIF,
+                                'rs', sample_rate=800*u.MHz/2048) as fh:
+            data = fh.read()
+            fh.seek(0)
+            with hdf5.open(filename, 'w', template=fh) as f5w:
+                assert f5w.complex_data
+                fh.read(out=f5w)
+
+        with hdf5.open(filename, 'r') as f5r:
+            self.check(fh, f5r)
+            recovered = f5r.read()
+
+        assert_array_equal(recovered, data)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_complex_stream(self, tmpdir):
+        filename = str(tmpdir.join('copy.hdf5'))
+        with baseband.vdif.open(baseband.data.SAMPLE_AROCHIME_VDIF,
+                                'rs', sample_rate=800*u.MHz/2048) as fh:
+            wrapped = SetAttribute(fh)
+            data = wrapped.read()
+            wrapped.seek(0)
+            with hdf5.open(filename, 'w', template=wrapped) as f5w:
+                assert f5w.complex_data
+                assert f5w.header0.encoded_dtype == 'c8'
+                wrapped.read(out=f5w)
+
+        with hdf5.open(filename, 'r') as f5r:
+            self.check(wrapped, f5r,
+                       ('sample_shape', 'dtype', 'sample_rate', 'time'))
+            assert f5r.header0.encoded_dtype == 'c8'
+            recovered = f5r.read()
+
+        # Cannot recover exactly, given scaling, but should be within
+        # tolerance for float16.
+        assert_array_equal(recovered, data)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_complex_stream_as_c4(self, tmpdir):
+        filename = str(tmpdir.join('copy.hdf5'))
+        with baseband.vdif.open(baseband.data.SAMPLE_AROCHIME_VDIF,
+                                'rs', sample_rate=800*u.MHz/2048) as fh:
+            wrapped = SetAttribute(fh)
+            data = wrapped.read()
+            wrapped.seek(0)
+            with hdf5.open(filename, 'w', template=wrapped,
+                           encoded_dtype='c4') as f5w:
+                assert f5w.complex_data
+                assert f5w.header0.encoded_dtype == hdf5.payload.DTYPE_C4
+                wrapped.read(out=f5w)
+
+        with hdf5.open(filename, 'r') as f5r:
+            self.check(wrapped, f5r,
+                       ('sample_shape', 'dtype', 'sample_rate', 'time'))
+            assert f5r.header0.encoded_dtype == hdf5.payload.DTYPE_C4
+            recovered = f5r.read()
+
+        # Cannot recover exactly, given scaling, but should be within
+        # tolerance for float16.
+        assert np.allclose(recovered, data, atol=0, rtol=np.finfo('f2').eps)
+
+    @pytest.mark.skipif(not HAS_H5PY, reason='h5py not available.')
+    def test_complex_stream_as_i1(self, tmpdir):
+        # Not a particularly good idea, but just to show it is possible.
+        filename = str(tmpdir.join('copy.hdf5'))
+        with hdf5.open(filename, 'w', template=self.wrapped,
+                       encoded_dtype='i1') as f5w:
+            assert not f5w.complex_data
+            assert f5w.header0.encoded_dtype == 'i1'
+            self.wrapped.read(out=f5w)
+
+        with hdf5.open(filename, 'r') as f5r:
+            self.check(self.wrapped, f5r,
+                       ('sample_shape', 'dtype', 'sample_rate', 'time'))
+            assert f5r.header0.encoded_dtype == 'i1'
+            recovered = f5r.read()
+
+        # Will not recover correctly, given the use of int, but should be
+        # within tolerance.
+        assert np.allclose(recovered, self.data, atol=0.5)


### PR DESCRIPTION
Using a new `encoded_dtype='c4'` argument.

cc @00rebe - this should be helpful for storing the files around giant pulses.