### PR TITLE
Added H5py to the optional requirements in documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,6 +19,7 @@ In addition, you may want to install:
       transforms.
     - `PINT <https://github.com/nanograv/PINT>`_ to calculate phases without
       first generating polycos.
+    - `H5py <https://www.h5py.org/>`_ to read files in the HDF5 format
 
 .. _installation:
 


### PR DESCRIPTION
I noticed that H5py was missing as an optional library in the documentation. I added a line for it.