### PR TITLE
Ensure Channelize samples_per_frame is used for calculating its shape.

### DIFF
--- a/scintillometry/channelize.py
+++ b/scintillometry/channelize.py
@@ -58,7 +58,8 @@ class Channelize(TaskBase):
                               ih.dtype, axis=1, sample_rate=ih.sample_rate)
 
         sample_rate = ih.sample_rate / n
-        shape = (ih.shape[0] // n,) + self._fft.frequency_shape[1:]
+        n_frames = (ih.shape[0] // n // samples_per_frame) * samples_per_frame
+        shape = (n_frames,) + self._fft.frequency_shape[1:]
         super().__init__(ih, shape=shape, sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame,
                          frequency=frequency, sideband=sideband,

--- a/scintillometry/tests/test_channelize.py
+++ b/scintillometry/tests/test_channelize.py
@@ -73,6 +73,26 @@ class TestChannelizeReal(UseVDIFSample):
         with pytest.raises(AttributeError):
             ct.ih
 
+    @pytest.mark.parametrize('samples_per_frame', [1, 16, 33])
+    def test_channelize_samples_per_frame(self, samples_per_frame):
+        """Test channelization task."""
+        ct = Channelize(self.fh, self.n, samples_per_frame=samples_per_frame)
+
+        # Channelize everything.
+        data1 = ct.read()
+        assert len(data1) % samples_per_frame == 0
+        assert (len(data1) // samples_per_frame
+                == len(self.ref_data) // samples_per_frame)
+        ref_data = self.ref_data[:len(data1)]
+        assert np.all(data1 == ref_data)
+
+        # Seeking and selective decode.
+        ct.seek(-3, 2)
+        assert ct.tell() == ct.shape[0] - 3
+        data2 = ct.read()
+        assert data2.shape[0] == 3
+        assert np.all(data2 == ref_data[-3:])
+
     def test_channelize_frequency_real(self):
         """Test frequency calculation."""
         ct = Channelize(self.fh_freq, self.n)


### PR DESCRIPTION
As it was, it was ignored which made it impossible to have values not equal to a factor of the input streams samples per frame.