### PR TITLE
Don't attempt to get attributes that are passed in as keywords.

### DIFF
--- a/scintillometry/io/hdf5/header.py
+++ b/scintillometry/io/hdf5/header.py
@@ -112,10 +112,10 @@ class HDF5Header(dict):
             else:
                 attrs = HDF5RawHeader._properties
 
-            for attr in attrs:
+            for attr in set(attrs) - kwargs.keys():
                 value = getattr(template, attr, None)
                 if value is not None:
-                    kwargs.setdefault(attr, value)
+                    kwargs[attr] = value
 
         return cls(verify=verify, **kwargs)
 


### PR DESCRIPTION
This since sometimes a given stream may error if trying to access
some information (e.g., trying to calculate a time from a phased
stream, in which sample_rate is in cycles), and in this case it
should still be possible to at least overwrite that property.

partially addresses #150