### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ astropy_header_packages =
     yaml
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst
+addopts = --doctest-rst --doctest-ignore-import-errors
 filterwarnings =
   error
   ignore:::pytest_doctestplus


### PR DESCRIPTION
Following https://github.com/mhvk/baseband/pull/393