### PR TITLE
Minimize test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ env:
         # Also allow tests without tox, getting our packages using apt;
         # Here, we still need pip to install baseband.  We use the Debian
         # version since the one packaged on travis gives some problems.
-        - APT_DEPENDENCIES='python3-astropy python3-pytest-astropy python3-setuptools python3-h5py python3-yaml python3-pyfftw python3-pip'
+        - APT_DEPENDENCIES="python3-astropy python3-pytest-astropy-header python3-pytest-doctestplus python3-pytest-openfiles python3-setuptools"
+        - APT_DEPENDENCIES="$APT_DEPENDENCIES python3-h5py python3-yaml python3-pyfftw python3-pip"
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,9 @@ all =
     pyyaml
     pint-pulsar
 test =
-    pytest-astropy
+    pytest-astropy-header
+    pytest-doctestplus
+    pytest-openfiles
 docs =
     sphinx-astropy
     pyfftw

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ test =
     pytest-astropy-header
     pytest-doctestplus
     pytest-openfiles
+cov =
+    pytest-cov
 docs =
     sphinx-astropy
     pyfftw

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
+    cov
     alldeps: all
 
 commands =


### PR DESCRIPTION
Want to be sure we only install what we actually use, also for testing.