### PR TITLE
Only get coverage installed if used.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ all =
 test =
     pytest-astropy-header
     pytest-doctestplus
-    pytest-openfiles
 cov =
     pytest-cov
 docs =

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ deps =
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
-    test
-    cov
+    test: test
+    cov: cov
     alldeps: all
 
 commands =


### PR DESCRIPTION
#170 was not quite right; this fixes it and also removes `pytest-openfiles` until it has been fixed (see #171)